### PR TITLE
Adds address to organisations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN unzip organisations.zip && rm organisations.zip
 
 EXPOSE 80
 
-CMD ["java", "-classpath", "/opt/organisations/organisations-0.0.1/lib/*", "-Dspring.profiles.active=production", "io.billie.ApplicationKt"]
+CMD ["java", "-classpath", "/opt/organisations/organisations-0.0.1/lib/*", "-D spring.profiles.active=production", "io.billie.ApplicationKt"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,3 +40,5 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.organisations.rule=PathPrefix(`/swagger-ui`) || PathPrefix(`/organisations`) || PathPrefix(`/countries`)"
       - "traefik.http.services.organisations.loadbalancer.server.port=80"
+    ports:
+      - "8080:8080"

--- a/src/main/kotlin/io/billie/organisations/data/OrganisationRepository.kt
+++ b/src/main/kotlin/io/billie/organisations/data/OrganisationRepository.kt
@@ -103,6 +103,7 @@ class OrganisationRepository {
             "o.id as id, " +
             "o.name as name, " +
             "o.date_founded as date_founded, " +
+            "o.address as address, " +
             "o.country_code as country_code, " +
             "c.id as country_id, " +
             "c.name as country_name, " +
@@ -123,6 +124,7 @@ class OrganisationRepository {
             it.getObject("id", UUID::class.java),
             it.getString("name"),
             Date(it.getDate("date_founded").time).toLocalDate(),
+            it.getString("address"),
             mapCountry(it),
             it.getString("vat_number"),
             it.getString("registration_number"),

--- a/src/main/kotlin/io/billie/organisations/data/OrganisationRepository.kt
+++ b/src/main/kotlin/io/billie/organisations/data/OrganisationRepository.kt
@@ -3,9 +3,7 @@ package io.billie.organisations.data
 import io.billie.countries.model.CountryResponse
 import io.billie.organisations.viewmodel.*
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.jdbc.core.JdbcTemplate
-import org.springframework.jdbc.core.ResultSetExtractor
-import org.springframework.jdbc.core.RowMapper
+import org.springframework.jdbc.core.*
 import org.springframework.jdbc.support.GeneratedKeyHolder
 import org.springframework.jdbc.support.KeyHolder
 import org.springframework.stereotype.Repository
@@ -26,6 +24,12 @@ class OrganisationRepository {
         return jdbcTemplate.query(organisationQuery(), organisationMapper())
     }
 
+    @Transactional(readOnly = true)
+    fun findOrganisationById(id: UUID): OrganisationResponse? {
+        return jdbcTemplate.queryForObject(organisationQuery(id), organisationMapper(), id)
+    }
+
+    @Throws(UnableToFindCountry::class)
     @Transactional
     fun create(organisation: OrganisationRequest): UUID {
         if(!valuesValid(organisation)) {
@@ -33,6 +37,38 @@ class OrganisationRepository {
         }
         val id: UUID = createContactDetails(organisation.contactDetails)
         return createOrganisation(organisation, id)
+    }
+
+    @Throws(UnableToFindOrganisation::class)
+    @Transactional
+    fun update(id: UUID, updateRequest: OrganisationRequest): UUID {
+        // Ensure that organisation id exists
+        findOrganisationById(id) ?: throw UnableToFindOrganisation(id)
+
+        jdbcTemplate.update { connection ->
+            val ps = connection.prepareStatement(
+                "UPDATE organisations_schema.organisations SET " +
+                            "name = ?, " +
+                            "date_founded = ?, " +
+                            "address = ?, " +
+                            "country_code = ?, " +
+                            "vat_number = ?, " +
+                            "registration_number = ? " +
+                            "WHERE id = ?"
+            )
+
+            ps.setString(1, updateRequest.name)
+            ps.setDate(2, Date.valueOf(updateRequest.dateFounded))
+            ps.setString(3, updateRequest.address)
+            ps.setString(4, updateRequest.countryCode)
+            ps.setString(5, updateRequest.VATNumber)
+            ps.setString(6, updateRequest.registrationNumber)
+            ps.setObject(7, id)
+
+            ps
+        }
+
+        return id
     }
 
     private fun valuesValid(organisation: OrganisationRequest): Boolean {
@@ -101,25 +137,34 @@ class OrganisationRepository {
         return keyHolder.getKeyAs(UUID::class.java)!!
     }
 
-    private fun organisationQuery() = "select " +
-            "o.id as id, " +
-            "o.name as name, " +
-            "o.date_founded as date_founded, " +
-            "o.address as address, " +
-            "o.country_code as country_code, " +
-            "c.id as country_id, " +
-            "c.name as country_name, " +
-            "o.VAT_number as VAT_number, " +
-            "o.registration_number as registration_number," +
-            "o.legal_entity_type as legal_entity_type," +
-            "o.contact_details_id as contact_details_id, " +
-            "cd.phone_number as phone_number, " +
-            "cd.fax as fax, " +
-            "cd.email as email " +
-            "from " +
-            "organisations_schema.organisations o " +
-            "INNER JOIN organisations_schema.contact_details cd on o.contact_details_id::uuid = cd.id::uuid " +
-            "INNER JOIN organisations_schema.countries c on o.country_code = c.country_code "
+    private fun organisationQuery(id: UUID? = null): String {
+
+        var query = "select " +
+                "o.id as id, " +
+                "o.name as name, " +
+                "o.date_founded as date_founded, " +
+                "o.address as address, " +
+                "o.country_code as country_code, " +
+                "c.id as country_id, " +
+                "c.name as country_name, " +
+                "o.VAT_number as VAT_number, " +
+                "o.registration_number as registration_number," +
+                "o.legal_entity_type as legal_entity_type," +
+                "o.contact_details_id as contact_details_id, " +
+                "cd.phone_number as phone_number, " +
+                "cd.fax as fax, " +
+                "cd.email as email " +
+                "from " +
+                "organisations_schema.organisations o " +
+                "INNER JOIN organisations_schema.contact_details cd on o.contact_details_id::uuid = cd.id::uuid " +
+                "INNER JOIN organisations_schema.countries c on o.country_code = c.country_code "
+
+        if (id != null) {
+            query += " WHERE o.id = ?"
+        }
+
+        return query
+    }
 
     private fun organisationMapper() = RowMapper<OrganisationResponse> { it: ResultSet, _: Int ->
         OrganisationResponse(

--- a/src/main/kotlin/io/billie/organisations/data/OrganisationRepository.kt
+++ b/src/main/kotlin/io/billie/organisations/data/OrganisationRepository.kt
@@ -55,21 +55,23 @@ class OrganisationRepository {
                     "INSERT INTO organisations_schema.organisations (" +
                             "name, " +
                             "date_founded, " +
+                            "address, " +
                             "country_code, " +
                             "vat_number, " +
                             "registration_number, " +
                             "legal_entity_type, " +
                             "contact_details_id" +
-                            ") VALUES (?, ?, ?, ?, ?, ?, ?)",
+                            ") VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
                     arrayOf("id")
                 )
                 ps.setString(1, org.name)
                 ps.setDate(2, Date.valueOf(org.dateFounded))
-                ps.setString(3, org.countryCode)
-                ps.setString(4, org.VATNumber)
-                ps.setString(5, org.registrationNumber)
-                ps.setString(6, org.legalEntityType.toString())
-                ps.setObject(7, contactDetailsId)
+                ps.setString(3, org.address)
+                ps.setString(4, org.countryCode)
+                ps.setString(5, org.VATNumber)
+                ps.setString(6, org.registrationNumber)
+                ps.setString(7, org.legalEntityType.toString())
+                ps.setObject(8, contactDetailsId)
                 ps
             }, keyHolder
         )

--- a/src/main/kotlin/io/billie/organisations/data/UnableToFindOrganisation.kt
+++ b/src/main/kotlin/io/billie/organisations/data/UnableToFindOrganisation.kt
@@ -1,0 +1,5 @@
+package io.billie.organisations.data
+
+import java.util.*
+
+class UnableToFindOrganisation(val organisationId: UUID) : RuntimeException()

--- a/src/main/kotlin/io/billie/organisations/resource/OrganisationResource.kt
+++ b/src/main/kotlin/io/billie/organisations/resource/OrganisationResource.kt
@@ -1,6 +1,7 @@
 package io.billie.organisations.resource
 
 import io.billie.organisations.data.UnableToFindCountry
+import io.billie.organisations.data.UnableToFindOrganisation
 import io.billie.organisations.service.OrganisationService
 import io.billie.organisations.viewmodel.*
 import io.swagger.v3.oas.annotations.media.ArraySchema
@@ -8,7 +9,6 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
-import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.server.ResponseStatusException
@@ -22,6 +22,15 @@ class OrganisationResource(val service: OrganisationService) {
 
     @GetMapping
     fun index(): List<OrganisationResponse> = service.findOrganisations()
+
+    @GetMapping("/{id}")
+    fun getOrganisationById(@PathVariable id: UUID?): OrganisationResponse? {
+        if (id == null) {
+            throw ResponseStatusException(BAD_REQUEST, "Id must be specified")
+        }
+
+        return service.findOrganisationById(id)
+    }
 
     @PostMapping
     @ApiResponses(
@@ -46,4 +55,13 @@ class OrganisationResource(val service: OrganisationService) {
         }
     }
 
+    @PutMapping("/{id}")
+    fun update(@PathVariable id: UUID, @Valid @RequestBody organisation: OrganisationRequest): Entity {
+        try {
+            val id = service.updateOrganisation(id, organisation)
+            return Entity(id)
+        } catch (e: UnableToFindOrganisation) {
+            throw ResponseStatusException(BAD_REQUEST, e.message)
+        }
+    }
 }

--- a/src/main/kotlin/io/billie/organisations/resource/OrganisationResource.kt
+++ b/src/main/kotlin/io/billie/organisations/resource/OrganisationResource.kt
@@ -58,8 +58,8 @@ class OrganisationResource(val service: OrganisationService) {
     @PutMapping("/{id}")
     fun update(@PathVariable id: UUID, @Valid @RequestBody organisation: OrganisationRequest): Entity {
         try {
-            val id = service.updateOrganisation(id, organisation)
-            return Entity(id)
+            val returnedId = service.updateOrganisation(id, organisation)
+            return Entity(returnedId)
         } catch (e: UnableToFindOrganisation) {
             throw ResponseStatusException(BAD_REQUEST, "Unable to update organisation - ${e.organisationId}.  ${e.message}")
         }

--- a/src/main/kotlin/io/billie/organisations/resource/OrganisationResource.kt
+++ b/src/main/kotlin/io/billie/organisations/resource/OrganisationResource.kt
@@ -51,7 +51,7 @@ class OrganisationResource(val service: OrganisationService) {
             val id = service.createOrganisation(organisation)
             return Entity(id)
         } catch (e: UnableToFindCountry) {
-            throw ResponseStatusException(BAD_REQUEST, e.message)
+            throw ResponseStatusException(BAD_REQUEST, "Unable to find country - ${e.countryCode}.  ${e.message}")
         }
     }
 
@@ -61,7 +61,7 @@ class OrganisationResource(val service: OrganisationService) {
             val id = service.updateOrganisation(id, organisation)
             return Entity(id)
         } catch (e: UnableToFindOrganisation) {
-            throw ResponseStatusException(BAD_REQUEST, e.message)
+            throw ResponseStatusException(BAD_REQUEST, "Unable to update organisation - ${e.organisationId}.  ${e.message}")
         }
     }
 }

--- a/src/main/kotlin/io/billie/organisations/service/OrganisationService.kt
+++ b/src/main/kotlin/io/billie/organisations/service/OrganisationService.kt
@@ -1,6 +1,8 @@
 package io.billie.organisations.service
 
 import io.billie.organisations.data.OrganisationRepository
+import io.billie.organisations.data.UnableToFindCountry
+import io.billie.organisations.data.UnableToFindOrganisation
 import io.billie.organisations.viewmodel.OrganisationRequest
 import io.billie.organisations.viewmodel.OrganisationResponse
 import org.springframework.stereotype.Service
@@ -10,9 +12,16 @@ import java.util.*
 class OrganisationService(val db: OrganisationRepository) {
 
     fun findOrganisations(): List<OrganisationResponse> = db.findOrganisations()
+    fun findOrganisationById(id: UUID): OrganisationResponse? = db.findOrganisationById(id)
 
+    @Throws(UnableToFindCountry::class)
     fun createOrganisation(organisation: OrganisationRequest): UUID {
         return db.create(organisation)
+    }
+
+    @Throws(UnableToFindOrganisation::class)
+    fun updateOrganisation(id: UUID, organisation: OrganisationRequest): UUID {
+        return db.update(id, organisation)
     }
 
 }

--- a/src/main/kotlin/io/billie/organisations/viewmodel/OrganisationRequest.kt
+++ b/src/main/kotlin/io/billie/organisations/viewmodel/OrganisationRequest.kt
@@ -11,6 +11,7 @@ import javax.validation.constraints.NotBlank
 data class OrganisationRequest(
     @field:NotBlank val name: String,
     @JsonFormat(pattern = "dd/MM/yyyy") @JsonProperty("date_founded") val dateFounded: LocalDate,
+    val address: String?,
     @field:NotBlank @JsonProperty("country_code") val countryCode: String,
     @JsonProperty("vat_number") val VATNumber: String?,
     @JsonProperty("registration_number") val registrationNumber: String?,

--- a/src/main/kotlin/io/billie/organisations/viewmodel/OrganisationResponse.kt
+++ b/src/main/kotlin/io/billie/organisations/viewmodel/OrganisationResponse.kt
@@ -12,6 +12,7 @@ data class OrganisationResponse(
     val id: UUID,
     val name: String,
     @JsonFormat(pattern = "dd/MM/yyyy") @JsonProperty("date_founded") val dateFounded: LocalDate,
+    val address: String?,
     val country: CountryResponse,
     @JsonProperty("vat_number") val VATNumber: String?,
     @JsonProperty("registration_number") val registrationNumber: String?,

--- a/src/main/resources/db/migration/V9__Add_address.sql
+++ b/src/main/resources/db/migration/V9__Add_address.sql
@@ -1,0 +1,1 @@
+ALTER TABLE organisations_schema.organisations ADD COLUMN address VARCHAR(256);

--- a/src/test/kotlin/io/billie/functional/CanReadLocationsTest.kt
+++ b/src/test/kotlin/io/billie/functional/CanReadLocationsTest.kt
@@ -1,28 +1,20 @@
 package io.billie.functional
 
 import io.billie.functional.matcher.IsUUID.isUuid
-import org.hamcrest.Description
-import org.hamcrest.TypeSafeMatcher
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.DEFINED_PORT
-import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import java.util.*
-
 
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = DEFINED_PORT)
 class CanReadLocationsTest {
-
-    @LocalServerPort
-    private val port = 8080
 
     @Autowired
     private lateinit var mockMvc: MockMvc

--- a/src/test/kotlin/io/billie/functional/CanRetrieveSingleOrganisationTest.kt
+++ b/src/test/kotlin/io/billie/functional/CanRetrieveSingleOrganisationTest.kt
@@ -8,7 +8,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.DEFINED_PORT
-import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -17,9 +16,6 @@ import org.assertj.core.api.Assertions.*
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = DEFINED_PORT)
 class CanRetrieveSingleOrganisationTest {
-
-    @LocalServerPort
-    private val port = 8080
 
     @Autowired
     private lateinit var mockMvc: MockMvc

--- a/src/test/kotlin/io/billie/functional/CanRetrieveSingleOrganisationTest.kt
+++ b/src/test/kotlin/io/billie/functional/CanRetrieveSingleOrganisationTest.kt
@@ -1,0 +1,52 @@
+package io.billie.functional
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.billie.organisations.viewmodel.OrganisationResponse
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.DEFINED_PORT
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import org.assertj.core.api.Assertions.*
+
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = DEFINED_PORT)
+class CanRetrieveSingleOrganisationTest {
+
+    @LocalServerPort
+    private val port = 8080
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var mapper: ObjectMapper
+
+    @Test
+    fun `Can retrieve single organisation`() {
+        val result = mockMvc.perform(
+            get("/organisations")
+        )
+        .andExpect(status().isOk)
+        .andReturn()
+
+        val organisationList = mapper.readValue<List<OrganisationResponse>>(result.response.contentAsString)
+
+        val firstOrganisation = organisationList[0]
+
+        val getSingleOrganisationResult = mockMvc.perform(
+            get("/organisations/${firstOrganisation.id}")
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+
+        val getSingleOrganisationResponse = mapper.readValue<OrganisationResponse>(getSingleOrganisationResult.response.contentAsString)
+
+        assertThat(getSingleOrganisationResponse == firstOrganisation).isTrue()
+    }
+}

--- a/src/test/kotlin/io/billie/functional/CanStoreAndReadOrganisationTest.kt
+++ b/src/test/kotlin/io/billie/functional/CanStoreAndReadOrganisationTest.kt
@@ -19,7 +19,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.DEFINED_PORT
-import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.web.servlet.MockMvc
@@ -32,9 +31,6 @@ import java.util.*
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = DEFINED_PORT)
 class CanStoreAndReadOrganisationTest {
-
-    @LocalServerPort
-    private val port = 8080
 
     @Autowired
     private lateinit var mockMvc: MockMvc

--- a/src/test/kotlin/io/billie/functional/CanStoreAndUpdateOrganisationTest.kt
+++ b/src/test/kotlin/io/billie/functional/CanStoreAndUpdateOrganisationTest.kt
@@ -10,7 +10,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.DEFINED_PORT
-import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.web.servlet.MockMvc
@@ -22,9 +21,6 @@ import org.assertj.core.api.Assertions.*
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = DEFINED_PORT)
 class CanStoreAndUpdateOrganisationTest {
-
-    @LocalServerPort
-    private val port = 8080
 
     @Autowired
     private lateinit var mockMvc: MockMvc
@@ -45,7 +41,7 @@ class CanStoreAndUpdateOrganisationTest {
 
         val response = mapper.readValue<Entity>(result.response.contentAsString)
 
-        val org: Map<String, Any> = orgFromDatabase(response.id)
+        val org: Map<String, Any> = queryEntityFromDatabase(response.id)
         assertThat(org["address"]).isEqualTo("123 Story Lane")
 
         val updateResult = mockMvc.perform(
@@ -61,7 +57,7 @@ class CanStoreAndUpdateOrganisationTest {
 
         assertThat(response.id).isEqualTo(updateResponse.id)
 
-        val updatedOrg: Map<String, Any> = orgFromDatabase(updateResponse.id)
+        val updatedOrg: Map<String, Any> = queryEntityFromDatabase(updateResponse.id)
 
         assertThat(updatedOrg["address"]).isEqualTo("456 Horse Road")
         assertThat(updatedOrg["vat_number"]).isEqualTo("555555555")
@@ -69,9 +65,7 @@ class CanStoreAndUpdateOrganisationTest {
         assertThat(updatedOrg["name"]).isEqualTo("My Organisation")
     }
 
-    private fun queryEntityFromDatabase(sql: String, id: UUID): MutableMap<String, Any> =
-        template.queryForMap(sql, id)
+    private fun queryEntityFromDatabase(id: UUID): MutableMap<String, Any> =
+        template.queryForMap("select * from organisations_schema.organisations where id = ?", id)
 
-    private fun orgFromDatabase(id: UUID): MutableMap<String, Any> =
-        queryEntityFromDatabase("select * from organisations_schema.organisations where id = ?", id)
 }

--- a/src/test/kotlin/io/billie/functional/CanStoreAndUpdateOrganisationTest.kt
+++ b/src/test/kotlin/io/billie/functional/CanStoreAndUpdateOrganisationTest.kt
@@ -1,0 +1,77 @@
+package io.billie.functional
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.billie.functional.data.Fixtures.orgAfterUpdateJson
+import io.billie.functional.data.Fixtures.orgBeforeUpdateJson
+import io.billie.organisations.viewmodel.Entity
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.DEFINED_PORT
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.http.MediaType.APPLICATION_JSON
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.*
+import org.assertj.core.api.Assertions.*
+
+@AutoConfigureMockMvc
+@SpringBootTest(webEnvironment = DEFINED_PORT)
+class CanStoreAndUpdateOrganisationTest {
+
+    @LocalServerPort
+    private val port = 8080
+
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var mapper: ObjectMapper
+
+    @Autowired
+    private lateinit var template: JdbcTemplate
+
+    @Test
+    fun `Can store and update org`() {
+        val result = mockMvc.perform(
+            post("/organisations").contentType(APPLICATION_JSON).content(orgBeforeUpdateJson())
+        )
+        .andExpect(status().isOk)
+        .andReturn()
+
+        val response = mapper.readValue<Entity>(result.response.contentAsString)
+
+        val org: Map<String, Any> = orgFromDatabase(response.id)
+        assertThat(org["address"]).isEqualTo("123 Story Lane")
+
+        val updateResult = mockMvc.perform(
+            put("/organisations/${response.id}")
+                .contentType(APPLICATION_JSON)
+                .accept(APPLICATION_JSON)
+                .content(orgAfterUpdateJson())
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+
+        val updateResponse = mapper.readValue<Entity>(updateResult.response.contentAsString)
+
+        assertThat(response.id).isEqualTo(updateResponse.id)
+
+        val updatedOrg: Map<String, Any> = orgFromDatabase(updateResponse.id)
+
+        assertThat(updatedOrg["address"]).isEqualTo("456 Horse Road")
+        assertThat(updatedOrg["vat_number"]).isEqualTo("555555555")
+        assertThat(updatedOrg["registration_number"]).isEqualTo("555555555")
+        assertThat(updatedOrg["name"]).isEqualTo("My Organisation")
+    }
+
+    private fun queryEntityFromDatabase(sql: String, id: UUID): MutableMap<String, Any> =
+        template.queryForMap(sql, id)
+
+    private fun orgFromDatabase(id: UUID): MutableMap<String, Any> =
+        queryEntityFromDatabase("select * from organisations_schema.organisations where id = ?", id)
+}

--- a/src/test/kotlin/io/billie/functional/data/Fixtures.kt
+++ b/src/test/kotlin/io/billie/functional/data/Fixtures.kt
@@ -67,6 +67,7 @@ object Fixtures {
         return "{\n" +
                 "  \"name\": \"BBC\",\n" +
                 "  \"date_founded\": \"18/10/1922\",\n" +
+                "  \"address\": \"123 Story Lane\",\n" +
                 "  \"country_code\": \"GB\",\n" +
                 "  \"vat_number\": \"333289454\",\n" +
                 "  \"registration_number\": \"3686147\",\n" +
@@ -131,6 +132,7 @@ object Fixtures {
         data["id"] = id
         data["name"] = "BBC"
         data["date_founded"] = SimpleDateFormat("yyyy-MM-dd").parse("1922-10-18")
+        data["address"] = "123 Story Lane"
         data["country_code"] = "GB"
         data["vat_number"] = "333289454"
         data["registration_number"] = "3686147"

--- a/src/test/kotlin/io/billie/functional/data/Fixtures.kt
+++ b/src/test/kotlin/io/billie/functional/data/Fixtures.kt
@@ -80,6 +80,40 @@ object Fixtures {
                 "}"
     }
 
+    fun orgBeforeUpdateJson(): String {
+        return "{\n" +
+                "  \"name\": \"BBC\",\n" +
+                "  \"date_founded\": \"18/10/1922\",\n" +
+                "  \"address\": \"123 Story Lane\",\n" +
+                "  \"country_code\": \"GB\",\n" +
+                "  \"vat_number\": \"333289454\",\n" +
+                "  \"registration_number\": \"3686147\",\n" +
+                "  \"legal_entity_type\": \"NONPROFIT_ORGANIZATION\",\n" +
+                "  \"contact_details\": {\n" +
+                "    \"phone_number\": \"+443700100222\",\n" +
+                "    \"fax\": \"\",\n" +
+                "    \"email\": \"yourquestions@bbc.co.uk\"\n" +
+                "  }\n" +
+                "}"
+    }
+
+    fun orgAfterUpdateJson(): String {
+        return "{\n" +
+                "  \"name\": \"My Organisation\",\n" +
+                "  \"date_founded\": \"18/10/1922\",\n" +
+                "  \"address\": \"456 Horse Road\",\n" +
+                "  \"country_code\": \"GB\",\n" +
+                "  \"vat_number\": \"555555555\",\n" +
+                "  \"registration_number\": \"555555555\",\n" +
+                "  \"legal_entity_type\": \"NONPROFIT_ORGANIZATION\",\n" +
+                "  \"contact_details\": {\n" +
+                "    \"phone_number\": \"+443700100222\",\n" +
+                "    \"fax\": \"\",\n" +
+                "    \"email\": \"yourquestions@bbc.co.uk\"\n" +
+                "  }\n" +
+                "}"
+    }
+
     fun orgRequestJsonCountryCodeBlank(): String {
         return "{\n" +
                 "  \"name\": \"BBC\",\n" +


### PR DESCRIPTION
This PR changes the following: 

- Adds address to organisations
- Allows the user to retrieve a single organisation by id
- Allows the user to update a single organisation by providing the id and the full organisation object.  Note that not all fields can be updated.
- Includes tests
