### PR TITLE
add address to organisations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ RUN apt-get update && apt-get install -y unzip
 COPY ./build/distributions/organisations-0.0.1.zip /opt/organisations/organisations.zip
 RUN unzip organisations.zip && rm organisations.zip
 
-EXPOSE 80
+EXPOSE 8080
 
 CMD ["java", "-classpath", "/opt/organisations/organisations-0.0.1/lib/*", "-Dspring.profiles.active=production", "io.billie.ApplicationKt"]

--- a/README.md
+++ b/README.md
@@ -47,10 +47,15 @@ Running the tests:
 ```shell
 cd <project_root>
 docker compose up database -d
-gradle flywayMigrate
 gradle clean build
 docs at -> http://localhost:8080/swagger-ui/index.html
 ```
 Work has been started but not done yet to containerise the kotlin service.
 
 The service runs in the host right now.  Feel free to fix that if it makes your life easier
+
+## Candidate notes:
+
+- Implemented adding address feature.
+- Containerised the service
+- Flyway migrations are now run on application start

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,6 @@ import java.util.*
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    id("org.flywaydb.flyway") version "9.3.1"
     id("org.springframework.boot") version "2.7.3"
     id("io.spring.dependency-management") version "1.0.14.RELEASE"
     kotlin("jvm") version "1.5.0"
@@ -17,6 +16,7 @@ group = "io.billie"
 version = "0.0.1"
 java.sourceCompatibility = JavaVersion.VERSION_11
 
+val flywayVersion = "9.16.0"
 
 val dbConf = Properties().apply {
     load(FileInputStream(File(rootProject.rootDir, "database.env")))
@@ -38,16 +38,10 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    implementation("org.flywaydb:flyway-core:$flywayVersion")
     runtimeOnly("org.postgresql:postgresql")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-}
-
-flyway {
-    url = dbConf.getProperty("DATABASE_URL")
-    user = dbConf.getProperty("POSTGRES_USER")
-    password = dbConf.getProperty("POSTGRES_PASSWORD")
-    locations = arrayOf(dbConf.getProperty("DATABASE_MIGRATION"))
 }
 
 tasks.withType<KotlinCompile> {
@@ -55,10 +49,6 @@ tasks.withType<KotlinCompile> {
         freeCompilerArgs = listOf("-Xjsr305=strict")
         jvmTarget = "11"
     }
-}
-
-tasks.named("build"){
-    dependsOn("flywayMigrate")
 }
 
 tasks.withType<Test> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,6 +57,10 @@ tasks.withType<KotlinCompile> {
     }
 }
 
+tasks.named("build"){
+    dependsOn("flywayMigrate")
+}
+
 tasks.withType<Test> {
     useJUnitPlatform()
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,9 @@ services:
     env_file:
       - database.env
       - service.env
+    environment:
+      - DATABASE_URL=jdbc:postgresql://database:5432/
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.organisations.rule=PathPrefix(`/swagger-ui`) || PathPrefix(`/organisations`) || PathPrefix(`/countries`)"
-      - "traefik.http.services.organisations.loadbalancer.server.port=80"
+      - "traefik.http.services.organisations.loadbalancer.server.port=8080"

--- a/src/main/kotlin/io/billie/ExceptionHandler.kt
+++ b/src/main/kotlin/io/billie/ExceptionHandler.kt
@@ -1,0 +1,16 @@
+package io.billie
+
+import io.billie.organisations.data.UnableToFindCity
+import io.billie.organisations.data.UnableToFindCountry
+import io.billie.organisations.data.UnableToFindOrganisation
+import org.springframework.http.HttpStatus
+import org.springframework.web.server.ResponseStatusException
+
+fun getHttpException(e: Exception): ResponseStatusException {
+    return when (e) {
+        is UnableToFindCountry -> ResponseStatusException(HttpStatus.BAD_REQUEST, e.message)
+        is UnableToFindOrganisation -> ResponseStatusException(HttpStatus.BAD_REQUEST, e.message)
+        is UnableToFindCity -> ResponseStatusException(HttpStatus.BAD_REQUEST, e.message)
+        else -> ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR)
+    }
+}

--- a/src/main/kotlin/io/billie/countries/data/CityRepository.kt
+++ b/src/main/kotlin/io/billie/countries/data/CityRepository.kt
@@ -1,8 +1,8 @@
 package io.billie.countries.data
 
 import io.billie.countries.model.CityResponse
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.jdbc.core.ResultSetExtractor
 import org.springframework.jdbc.core.RowMapper
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
@@ -10,11 +10,9 @@ import java.sql.ResultSet
 import java.util.*
 
 @Repository
-class CityRepository {
-
-
-    @Autowired
-    lateinit var jdbcTemplate: JdbcTemplate
+class CityRepository(
+    private val jdbcTemplate: JdbcTemplate,
+) {
 
     @Transactional(readOnly = true)
     fun findByCountryCode(countryCode: String): List<CityResponse> {
@@ -23,6 +21,18 @@ class CityRepository {
             cityResponseMapper(),
             countryCode
         )
+    }
+
+    fun existsById(cityId: UUID): Boolean {
+        val exists = jdbcTemplate.query(
+            "SELECT EXISTS(SELECT 1 FROM organisations_schema.cities WHERE id = ?)",
+            ResultSetExtractor {
+                it.next()
+                it.getBoolean(1)
+            },
+            cityId,
+        )
+        return exists != null && exists
     }
 
     private fun cityResponseMapper() = RowMapper<CityResponse> { it: ResultSet, _: Int ->

--- a/src/main/kotlin/io/billie/countries/data/CountryRepository.kt
+++ b/src/main/kotlin/io/billie/countries/data/CountryRepository.kt
@@ -1,7 +1,6 @@
 package io.billie.countries.data
 
 import io.billie.countries.model.CountryResponse
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.jdbc.core.RowMapper
 import org.springframework.stereotype.Repository
@@ -10,10 +9,9 @@ import java.sql.ResultSet
 import java.util.*
 
 @Repository
-class CountryRepository {
-
-    @Autowired
-    lateinit var jdbcTemplate: JdbcTemplate
+class CountryRepository(
+    private val jdbcTemplate: JdbcTemplate
+){
 
     @Transactional(readOnly=true)
     fun findCountries(): List<CountryResponse> {

--- a/src/main/kotlin/io/billie/organisations/data/OrganisationRepository.kt
+++ b/src/main/kotlin/io/billie/organisations/data/OrganisationRepository.kt
@@ -1,8 +1,13 @@
 package io.billie.organisations.data
 
 import io.billie.countries.model.CountryResponse
-import io.billie.organisations.viewmodel.*
-import org.springframework.beans.factory.annotation.Autowired
+import io.billie.organisations.viewmodel.Address
+import io.billie.organisations.viewmodel.AddressRequest
+import io.billie.organisations.viewmodel.ContactDetails
+import io.billie.organisations.viewmodel.ContactDetailsRequest
+import io.billie.organisations.viewmodel.LegalEntityType
+import io.billie.organisations.viewmodel.OrganisationRequest
+import io.billie.organisations.viewmodel.OrganisationResponse
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.jdbc.core.ResultSetExtractor
 import org.springframework.jdbc.core.RowMapper
@@ -12,14 +17,13 @@ import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
 import java.sql.Date
 import java.sql.ResultSet
-import java.util.*
+import java.util.UUID
 
 
 @Repository
-class OrganisationRepository {
-
-    @Autowired
-    lateinit var jdbcTemplate: JdbcTemplate
+class OrganisationRepository(
+    private val jdbcTemplate: JdbcTemplate,
+) {
 
     @Transactional(readOnly = true)
     fun findOrganisations(): List<OrganisationResponse> {
@@ -28,39 +32,89 @@ class OrganisationRepository {
 
     @Transactional
     fun create(organisation: OrganisationRequest): UUID {
-        if(!valuesValid(organisation)) {
+        if (!validateCountryExists(organisation.countryCode)) {
             throw UnableToFindCountry(organisation.countryCode)
         }
-        val id: UUID = createContactDetails(organisation.contactDetails)
-        return createOrganisation(organisation, id)
+        val contactDetailsId: UUID = createContactDetails(organisation.contactDetails)
+        return createOrganisation(
+            org = organisation,
+            contactDetailsId = contactDetailsId,
+            addressId = organisation.addressRequest?.let { createAddress(it) }
+        )
     }
 
-    private fun valuesValid(organisation: OrganisationRequest): Boolean {
+    fun createAddress(addressRequest: AddressRequest): UUID {
+        val keyHolder: KeyHolder = GeneratedKeyHolder()
+        jdbcTemplate.update(
+            { connection ->
+                val ps = connection.prepareStatement(
+                    """
+                    insert into organisations_schema.addresses
+                    (
+                     city_id,
+                     zip_code,
+                     street,
+                     street_number,
+                     apartment_number
+                    ) values(?,?,?,?,?)
+                    """,
+                    arrayOf("id")
+                )
+                ps.setObject(1, UUID.fromString(addressRequest.cityId))
+                ps.setString(2, addressRequest.zipCode)
+                ps.setString(3, addressRequest.street)
+                ps.setString(4, addressRequest.streetNumber)
+                ps.setString(5, addressRequest.apartmentNumber)
+                ps
+            },
+            keyHolder
+        )
+        return keyHolder.getKeyAs(UUID::class.java)!!
+    }
+
+    fun addAddressToOrganisation(organisationId: UUID, addressId: UUID) {
+        jdbcTemplate.update { connection ->
+            val ps = connection.prepareStatement(
+                """
+                    UPDATE organisations_schema.organisations
+                    SET address_id = ?
+                    WHERE id = ?
+                    """
+            )
+            ps.setObject(1, addressId)
+            ps.setObject(2, organisationId)
+            ps
+        }
+    }
+
+    private fun validateCountryExists(countryCode: String): Boolean {
         val reply: Int? = jdbcTemplate.query(
             "select count(country_code) from organisations_schema.countries c WHERE c.country_code = ?",
             ResultSetExtractor {
                 it.next()
                 it.getInt(1)
             },
-            organisation.countryCode
+            countryCode
         )
         return (reply != null) && (reply > 0)
     }
 
-    private fun createOrganisation(org: OrganisationRequest, contactDetailsId: UUID): UUID {
+    private fun createOrganisation(org: OrganisationRequest, contactDetailsId: UUID, addressId: UUID? = null): UUID {
         val keyHolder: KeyHolder = GeneratedKeyHolder()
         jdbcTemplate.update(
             { connection ->
                 val ps = connection.prepareStatement(
-                    "INSERT INTO organisations_schema.organisations (" +
-                            "name, " +
-                            "date_founded, " +
-                            "country_code, " +
-                            "vat_number, " +
-                            "registration_number, " +
-                            "legal_entity_type, " +
-                            "contact_details_id" +
-                            ") VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    """INSERT INTO organisations_schema.organisations (
+                        name, 
+                        date_founded, 
+                        country_code, 
+                        vat_number, 
+                        registration_number, 
+                        legal_entity_type, 
+                        contact_details_id,
+                        address_id) 
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?)"""
+                        .trimMargin(),
                     arrayOf("id")
                 )
                 ps.setString(1, org.name)
@@ -70,6 +124,7 @@ class OrganisationRepository {
                 ps.setString(5, org.registrationNumber)
                 ps.setString(6, org.legalEntityType.toString())
                 ps.setObject(7, contactDetailsId)
+                ps.setObject(8, addressId)
                 ps
             }, keyHolder
         )
@@ -81,12 +136,14 @@ class OrganisationRepository {
         jdbcTemplate.update(
             { connection ->
                 val ps = connection.prepareStatement(
-                    "insert into organisations_schema.contact_details " +
-                            "(" +
-                            "phone_number, " +
-                            "fax, " +
-                            "email" +
-                            ") values(?,?,?)",
+                    """
+                    insert into organisations_schema.contact_details 
+                    (
+                    phone_number, 
+                    fax, 
+                    email
+                    ) values(?,?,?)
+                    """,
                     arrayOf("id")
                 )
                 ps.setString(1, contactDetails.phoneNumber)
@@ -99,24 +156,38 @@ class OrganisationRepository {
         return keyHolder.getKeyAs(UUID::class.java)!!
     }
 
-    private fun organisationQuery() = "select " +
-            "o.id as id, " +
-            "o.name as name, " +
-            "o.date_founded as date_founded, " +
-            "o.country_code as country_code, " +
-            "c.id as country_id, " +
-            "c.name as country_name, " +
-            "o.VAT_number as VAT_number, " +
-            "o.registration_number as registration_number," +
-            "o.legal_entity_type as legal_entity_type," +
-            "o.contact_details_id as contact_details_id, " +
-            "cd.phone_number as phone_number, " +
-            "cd.fax as fax, " +
-            "cd.email as email " +
-            "from " +
-            "organisations_schema.organisations o " +
-            "INNER JOIN organisations_schema.contact_details cd on o.contact_details_id::uuid = cd.id::uuid " +
-            "INNER JOIN organisations_schema.countries c on o.country_code = c.country_code "
+    private fun organisationQuery() =
+        """
+            SELECT 
+                o.id as id, 
+                o.name as name, 
+                o.date_founded as date_founded, 
+                o.country_code as country_code, 
+                c.id as country_id, 
+                c.name as country_name, 
+                o.VAT_number as VAT_number, 
+                o.registration_number as registration_number,
+                o.legal_entity_type as legal_entity_type,
+                o.contact_details_id as contact_details_id, 
+                cd.phone_number as phone_number, 
+                cd.fax as fax, 
+                cd.email as email,
+                a.id as address_id,
+                a.city_id as city_id,
+                a.zip_code as zip_code,
+                a.street as street,
+                a.street_number as street_number,
+                a.apartment_number as apartment_number
+            FROM 
+                organisations_schema.organisations o 
+            INNER JOIN 
+                organisations_schema.contact_details cd on o.contact_details_id::uuid = cd.id::uuid 
+            INNER JOIN 
+                organisations_schema.countries c on o.country_code = c.country_code
+            LEFT JOIN 
+                organisations_schema.addresses a on o.address_id::uuid = a.id::uuid
+        """
+
 
     private fun organisationMapper() = RowMapper<OrganisationResponse> { it: ResultSet, _: Int ->
         OrganisationResponse(
@@ -127,8 +198,22 @@ class OrganisationRepository {
             it.getString("vat_number"),
             it.getString("registration_number"),
             LegalEntityType.valueOf(it.getString("legal_entity_type")),
-            mapContactDetails(it)
+            mapContactDetails(it),
+            mapAddress(it),
         )
+    }
+
+    private fun mapAddress(resultSet: ResultSet): Address? {
+        return resultSet.getString("address_id")?.let {
+            Address(
+                id = UUID.fromString(it),
+                cityId = resultSet.getString("city_id"),
+                zipCode = resultSet.getString("zip_code"),
+                street = resultSet.getString("street"),
+                streetNumber = resultSet.getString("street_number"),
+                apartmentNumber = resultSet.getString("apartment_number")
+            )
+        }
     }
 
     private fun mapContactDetails(it: ResultSet): ContactDetails {
@@ -148,4 +233,15 @@ class OrganisationRepository {
         )
     }
 
+    fun existsById(organisationId: UUID): Boolean {
+        val exists = jdbcTemplate.query(
+            "SELECT EXISTS(SELECT 1 FROM organisations_schema.organisations WHERE id = ?)",
+            ResultSetExtractor {
+                it.next()
+                it.getBoolean(1)
+            },
+            organisationId,
+        )
+        return exists != null && exists
+    }
 }

--- a/src/main/kotlin/io/billie/organisations/data/UnableToFindCity.kt
+++ b/src/main/kotlin/io/billie/organisations/data/UnableToFindCity.kt
@@ -1,0 +1,3 @@
+package io.billie.organisations.data
+
+class UnableToFindCity(cityId: String) : RuntimeException("City not found for id $cityId")

--- a/src/main/kotlin/io/billie/organisations/data/UnableToFindCountry.kt
+++ b/src/main/kotlin/io/billie/organisations/data/UnableToFindCountry.kt
@@ -1,3 +1,3 @@
 package io.billie.organisations.data
 
-class UnableToFindCountry(val countryCode: String) : RuntimeException()
+class UnableToFindCountry(countryCode: String) : RuntimeException("Country not found by code $countryCode")

--- a/src/main/kotlin/io/billie/organisations/data/UnableToFindOrganisation.kt
+++ b/src/main/kotlin/io/billie/organisations/data/UnableToFindOrganisation.kt
@@ -1,0 +1,4 @@
+package io.billie.organisations.data
+
+class UnableToFindOrganisation(organisationId: String) :
+    RuntimeException("Organisation not found by id $organisationId")

--- a/src/main/kotlin/io/billie/organisations/resource/OrganisationResource.kt
+++ b/src/main/kotlin/io/billie/organisations/resource/OrganisationResource.kt
@@ -1,6 +1,6 @@
 package io.billie.organisations.resource
 
-import io.billie.organisations.data.UnableToFindCountry
+import io.billie.getHttpException
 import io.billie.organisations.service.OrganisationService
 import io.billie.organisations.viewmodel.*
 import io.swagger.v3.oas.annotations.media.ArraySchema
@@ -8,10 +8,7 @@ import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
-import org.springframework.http.HttpStatus
-import org.springframework.http.HttpStatus.BAD_REQUEST
 import org.springframework.web.bind.annotation.*
-import org.springframework.web.server.ResponseStatusException
 import java.util.*
 import javax.validation.Valid
 
@@ -41,8 +38,35 @@ class OrganisationResource(val service: OrganisationService) {
         try {
             val id = service.createOrganisation(organisation)
             return Entity(id)
-        } catch (e: UnableToFindCountry) {
-            throw ResponseStatusException(BAD_REQUEST, e.message)
+        } catch (e: Exception) {
+            throw getHttpException(e)
+        }
+    }
+
+
+    @PostMapping("/{organisationId}/addresses")
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "Added address to organisation",
+                content = [
+                    (Content(
+                        mediaType = "application/json",
+                        array = (ArraySchema(schema = Schema(implementation = Entity::class)))
+                    ))]
+            ),
+            ApiResponse(responseCode = "400", description = "Bad request", content = [Content()])]
+    )
+    fun post(
+        @Valid @RequestBody addressRequest: AddressRequest,
+        @PathVariable organisationId: String,
+    ): Entity {
+        try {
+            val id = service.addAddressToOrganisation(organisationId, addressRequest)
+            return Entity(id)
+        } catch (e: Exception) {
+            throw getHttpException(e)
         }
     }
 

--- a/src/main/kotlin/io/billie/organisations/service/OrganisationService.kt
+++ b/src/main/kotlin/io/billie/organisations/service/OrganisationService.kt
@@ -1,18 +1,44 @@
 package io.billie.organisations.service
 
+import io.billie.countries.data.CityRepository
 import io.billie.organisations.data.OrganisationRepository
+import io.billie.organisations.data.UnableToFindCity
+import io.billie.organisations.data.UnableToFindOrganisation
+import io.billie.organisations.viewmodel.AddressRequest
 import io.billie.organisations.viewmodel.OrganisationRequest
 import io.billie.organisations.viewmodel.OrganisationResponse
 import org.springframework.stereotype.Service
 import java.util.*
 
 @Service
-class OrganisationService(val db: OrganisationRepository) {
+class OrganisationService(
+    private val organisationRepository: OrganisationRepository,
+    private val cityRepository: CityRepository,
+) {
 
-    fun findOrganisations(): List<OrganisationResponse> = db.findOrganisations()
+    fun findOrganisations(): List<OrganisationResponse> = organisationRepository.findOrganisations()
 
     fun createOrganisation(organisation: OrganisationRequest): UUID {
-        return db.create(organisation)
+        return organisationRepository.create(organisation)
     }
 
+    fun addAddressToOrganisation(organisationId: String, addressRequest: AddressRequest): UUID {
+        validateOrganisationExists(organisationId)
+        validateCityExists(addressRequest.cityId)
+        val addressId = organisationRepository.createAddress(addressRequest)
+        organisationRepository.addAddressToOrganisation(UUID.fromString(organisationId), addressId)
+        return addressId
+    }
+
+    private fun validateCityExists(cityId: String) {
+        if (!cityRepository.existsById(UUID.fromString(cityId))) {
+            throw UnableToFindCity(cityId)
+        }
+    }
+
+    private fun validateOrganisationExists(organisationId: String) {
+        if (!organisationRepository.existsById(UUID.fromString(organisationId))) {
+            throw UnableToFindOrganisation(organisationId)
+        }
+    }
 }

--- a/src/main/kotlin/io/billie/organisations/viewmodel/Address.kt
+++ b/src/main/kotlin/io/billie/organisations/viewmodel/Address.kt
@@ -1,0 +1,13 @@
+package io.billie.organisations.viewmodel
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.util.UUID
+
+data class Address(
+    val id: UUID,
+    @JsonProperty("city_id") val cityId: String,
+    @JsonProperty("zip_code") val zipCode: String,
+    val street: String,
+    @JsonProperty("street_number") val streetNumber: String,
+    @JsonProperty("apartment_number") val apartmentNumber: String?,
+)

--- a/src/main/kotlin/io/billie/organisations/viewmodel/AddressRequest.kt
+++ b/src/main/kotlin/io/billie/organisations/viewmodel/AddressRequest.kt
@@ -1,0 +1,14 @@
+package io.billie.organisations.viewmodel
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.util.*
+import javax.validation.constraints.NotBlank
+import javax.validation.constraints.Size
+
+data class AddressRequest(
+    @field:NotBlank  @JsonProperty("city_id") val cityId: String,
+    @field:Size(max = 10) @field:NotBlank @JsonProperty("zip_code") val zipCode: String,
+    @field:Size(max = 50) @field:NotBlank val street: String,
+    @field:Size(max = 10) @field:NotBlank @JsonProperty("street_number") val streetNumber: String,
+    @field:Size(max = 5) @JsonProperty("apartment_number") val apartmentNumber: String? = null,
+)

--- a/src/main/kotlin/io/billie/organisations/viewmodel/OrganisationRequest.kt
+++ b/src/main/kotlin/io/billie/organisations/viewmodel/OrganisationRequest.kt
@@ -2,12 +2,10 @@ package io.billie.organisations.viewmodel
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonProperty
-import org.springframework.data.relational.core.mapping.Table
 import java.time.LocalDate
 import java.util.*
 import javax.validation.constraints.NotBlank
 
-@Table("ORGANISATIONS")
 data class OrganisationRequest(
     @field:NotBlank val name: String,
     @JsonFormat(pattern = "dd/MM/yyyy") @JsonProperty("date_founded") val dateFounded: LocalDate,
@@ -16,4 +14,5 @@ data class OrganisationRequest(
     @JsonProperty("registration_number") val registrationNumber: String?,
     @JsonProperty("legal_entity_type") val legalEntityType: LegalEntityType,
     @JsonProperty("contact_details") val contactDetails: ContactDetailsRequest,
+    @JsonProperty("address") val addressRequest: AddressRequest? = null,
 )

--- a/src/main/kotlin/io/billie/organisations/viewmodel/OrganisationResponse.kt
+++ b/src/main/kotlin/io/billie/organisations/viewmodel/OrganisationResponse.kt
@@ -3,11 +3,9 @@ package io.billie.organisations.viewmodel
 import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonProperty
 import io.billie.countries.model.CountryResponse
-import org.springframework.data.relational.core.mapping.Table
 import java.time.LocalDate
 import java.util.*
 
-@Table("ORGANISATIONS")
 data class OrganisationResponse(
     val id: UUID,
     val name: String,
@@ -17,4 +15,5 @@ data class OrganisationResponse(
     @JsonProperty("registration_number") val registrationNumber: String?,
     @JsonProperty("legal_entity_type") val legalEntityType: LegalEntityType,
     @JsonProperty("contact_details") val contactDetails: ContactDetails,
+    @JsonProperty("address") val address: Address?,
 )

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,5 +3,3 @@ spring.datasource.driver-class-name=${DATABASE_DRIVER}
 spring.datasource.url=${DATABASE_URL}
 spring.datasource.username=${POSTGRES_USER}
 spring.datasource.password=${POSTGRES_PASSWORD}
-spring.datasource.schema=${DATABASE_SCHEMA}
-spring.datasource.initialization-mode=always

--- a/src/main/resources/db/migration/V10__add_address_to_organisation.sql
+++ b/src/main/resources/db/migration/V10__add_address_to_organisation.sql
@@ -1,0 +1,2 @@
+ALTER TABLE organisations_schema.organisations
+    ADD COLUMN address_id UUID REFERENCES organisations_schema.addresses(id);

--- a/src/main/resources/db/migration/V9__add_addresses_table.sql
+++ b/src/main/resources/db/migration/V9__add_addresses_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS organisations_schema.addresses
+(
+    id                  UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+    city_id             UUID REFERENCES organisations_schema.cities(id),
+    zip_code            VARCHAR(10) NOT NULL,
+    street              VARCHAR(50) NOT NULL,
+    street_number       VARCHAR(10) NOT NULL,
+    apartment_number    VARCHAR(5)
+);

--- a/src/test/kotlin/io/billie/ExceptionHandlerKtTest.kt
+++ b/src/test/kotlin/io/billie/ExceptionHandlerKtTest.kt
@@ -1,0 +1,53 @@
+package io.billie
+
+import io.billie.organisations.data.UnableToFindCity
+import io.billie.organisations.data.UnableToFindCountry
+import io.billie.organisations.data.UnableToFindOrganisation
+import org.junit.jupiter.api.Assertions.*
+
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+
+class ExceptionHandlerTest {
+
+    @Test
+    fun `getHttpException returns BAD_REQUEST for UnableToFindCountry`() {
+        val exception = UnableToFindCountry("DE")
+
+        val result = getHttpException(exception)
+
+        assertEquals(HttpStatus.BAD_REQUEST, result.status)
+        assertEquals("Country not found by code DE", result.reason)
+    }
+
+    @Test
+    fun `getHttpException returns BAD_REQUEST for UnableToFindOrganisation`() {
+        val orgId = "123"
+        val exception = UnableToFindOrganisation(orgId)
+
+        val result = getHttpException(exception)
+
+        assertEquals(HttpStatus.BAD_REQUEST, result.status)
+        assertEquals("Organisation not found by id $orgId", result.reason)
+    }
+
+    @Test
+    fun `getHttpException returns BAD_REQUEST for UnableToFindCity`() {
+        val cityId = "123"
+        val exception = UnableToFindCity(cityId)
+
+        val result = getHttpException(exception)
+
+        assertEquals(HttpStatus.BAD_REQUEST, result.status)
+        assertEquals("City not found for id $cityId", result.reason)
+    }
+
+    @Test
+    fun `getHttpException returns INTERNAL_SERVER_ERROR for any other exception`() {
+        val exception = RuntimeException("Runtime exception")
+
+        val result = getHttpException(exception)
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, result.status)
+    }
+}

--- a/src/test/kotlin/io/billie/functional/CanReadLocationsTest.kt
+++ b/src/test/kotlin/io/billie/functional/CanReadLocationsTest.kt
@@ -1,28 +1,21 @@
 package io.billie.functional
 
 import io.billie.functional.matcher.IsUUID.isUuid
-import org.hamcrest.Description
-import org.hamcrest.TypeSafeMatcher
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.DEFINED_PORT
-import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import java.util.*
 
 
 @AutoConfigureMockMvc
-@SpringBootTest(webEnvironment = DEFINED_PORT)
+@SpringBootTest(webEnvironment = RANDOM_PORT)
 class CanReadLocationsTest {
-
-    @LocalServerPort
-    private val port = 8080
 
     @Autowired
     private lateinit var mockMvc: MockMvc

--- a/src/test/kotlin/io/billie/functional/CanStoreAndReadOrganisationTest.kt
+++ b/src/test/kotlin/io/billie/functional/CanStoreAndReadOrganisationTest.kt
@@ -1,6 +1,9 @@
 package io.billie.functional
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import io.billie.countries.data.CityRepository
+import io.billie.functional.data.Fixtures
+import io.billie.functional.data.Fixtures.bbcAddressFixture
 import io.billie.functional.data.Fixtures.bbcContactFixture
 import io.billie.functional.data.Fixtures.bbcFixture
 import io.billie.functional.data.Fixtures.orgRequestJson
@@ -11,10 +14,15 @@ import io.billie.functional.data.Fixtures.orgRequestJsonNameBlank
 import io.billie.functional.data.Fixtures.orgRequestJsonNoContactDetails
 import io.billie.functional.data.Fixtures.orgRequestJsonNoCountryCode
 import io.billie.functional.data.Fixtures.orgRequestJsonNoLegalEntityType
+import io.billie.organisations.data.OrganisationRepository
 import io.billie.organisations.viewmodel.Entity
+import io.billie.organisations.viewmodel.OrganisationRequest
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.IsEqual.equalTo
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
@@ -26,6 +34,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.util.*
+import java.util.stream.Stream
 
 
 @AutoConfigureMockMvc
@@ -40,6 +49,12 @@ class CanStoreAndReadOrganisationTest {
 
     @Autowired
     private lateinit var template: JdbcTemplate
+
+    @Autowired
+    private lateinit var organisationRepository: OrganisationRepository
+
+    @Autowired
+    private lateinit var cityRepository : CityRepository
 
     @Test
     fun orgs() {
@@ -124,7 +139,97 @@ class CanStoreAndReadOrganisationTest {
         assertDataMatches(contactDetails, bbcContactFixture(contactDetailsId))
     }
 
-    fun assertDataMatches(reply: Map<String, Any>, assertions: Map<String, Any>) {
+    @Test
+    fun `can add address to existing organisation`() {
+        val cityId = cityRepository.findByCountryCode("NL").first().id
+        // create an organisation without address
+        val organisationId = organisationRepository.create(mapper.readValue(orgRequestJson(), OrganisationRequest::class.java))
+        // add address
+        val result = mockMvc.perform(
+            post("/organisations/$organisationId/addresses").contentType(APPLICATION_JSON).content(
+                Fixtures.addressRequestJson(
+                    cityId.toString()
+                )
+            )
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+
+        val response = mapper.readValue(result.response.contentAsString, Entity::class.java)
+
+        val org: Map<String, Any> = orgFromDatabase(organisationId)
+        assertDataMatches(org, bbcFixture(organisationId))
+
+        val addressId: UUID = response.id
+        val address: Map<String, Any> = addressFromDatabase(addressId)
+        assertDataMatches(address, Fixtures.bbcAddressFixture(addressId))
+    }
+
+    @Test
+    fun `can store organisation with address`() {
+        val cityId = cityRepository.findByCountryCode("NL").first().id
+        val result = mockMvc.perform(
+            post("/organisations").contentType(APPLICATION_JSON).content(Fixtures.orgRequestWithAddressJson(cityId.toString()))
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+
+        val response = mapper.readValue(result.response.contentAsString, Entity::class.java)
+
+        val org: Map<String, Any> = orgFromDatabase(response.id)
+        assertDataMatches(org, bbcFixture(response.id))
+
+        val contactDetailsId: UUID = UUID.fromString(org["contact_details_id"] as String)
+        val addressId: UUID = org["address_id"] as UUID
+        val contactDetails: Map<String, Any> = contactDetailsFromDatabase(contactDetailsId)
+        val address: Map<String, Any> = addressFromDatabase(addressId)
+        assertDataMatches(contactDetails, bbcContactFixture(contactDetailsId))
+        assertDataMatches(address, bbcAddressFixture(addressId))
+    }
+
+
+    @ParameterizedTest
+    @MethodSource("validAddressRequests")
+    fun `stores valid addresses`(caseIdentifier: String, payload: MutableMap<String, Any>) {
+        val organisationId = organisationRepository.create(mapper.readValue(orgRequestJson(), OrganisationRequest::class.java))
+        val cityId = cityRepository.findByCountryCode("NL").first().id
+        payload["city_id"] = cityId
+        val result = mockMvc.perform(
+            post("/organisations/$organisationId/addresses").contentType(APPLICATION_JSON)
+                .content(mapper.writeValueAsString(payload))
+        )
+            .andExpect(status().isOk)
+            .andReturn()
+
+        val response = mapper.readValue(result.response.contentAsString, Entity::class.java)
+
+        val address: Map<String, Any> = addressFromDatabase(response.id)
+        assertDataMatches(
+            address,
+            mapOf(
+                "id" to response.id,
+                "city_id" to cityId,
+                "zip_code" to payload["zip_code"],
+                "street" to payload["street"],
+                "street_number" to payload["street_number"],
+                "apartment_number" to payload["apartment_number"]
+            )
+        )
+    }
+
+    @ParameterizedTest
+    @MethodSource("invalidAddressRequests")
+    fun `invalid addresses return http 400`(caseIdentifier: String, payload: MutableMap<String, Any>) {
+        val organisationId = UUID.randomUUID()
+        mockMvc.perform(
+            post("/organisations/$organisationId/addresses").contentType(APPLICATION_JSON)
+                .content(mapper.writeValueAsString(payload))
+        )
+            .andExpect(status().isBadRequest)
+            .andReturn()
+    }
+
+    fun assertDataMatches(reply: Map<String, Any>, assertions: Map<String, Any?>) {
         for (key in assertions.keys) {
             assertThat(reply[key], equalTo(assertions[key]))
         }
@@ -139,4 +244,74 @@ class CanStoreAndReadOrganisationTest {
     private fun contactDetailsFromDatabase(id: UUID): MutableMap<String, Any> =
         queryEntityFromDatabase("select * from organisations_schema.contact_details where id = ?", id)
 
+    private fun addressFromDatabase(id: UUID): MutableMap<String, Any> =
+        queryEntityFromDatabase("select * from organisations_schema.addresses where id = ?", id)
+
+    companion object {
+        private fun buildAddressRequestMap(replace: Map<String, Any?> = emptyMap()): MutableMap<String, Any?> {
+            val addressRequestMap = mutableMapOf<String, Any?>(
+                "city_id" to UUID.randomUUID(),
+                "zip_code" to "1046AC",
+                "street" to "Jarmuiden",
+                "street_number" to "31",
+                "apartment_number" to "4A"
+            )
+            addressRequestMap.putAll(replace)
+            return addressRequestMap
+        }
+        @JvmStatic
+        fun validAddressRequests(): Stream<Arguments> {
+            return Stream.of(
+                Arguments.of(
+                    "full address",
+                    buildAddressRequestMap()
+                ),
+                Arguments.of(
+                    "no apartmentNumber provided",
+                    buildAddressRequestMap(mapOf("apartment_number" to null))
+                ),
+                Arguments.of(
+                    "zip code max length",
+                     buildAddressRequestMap(mapOf("zip_code" to "a".repeat(10)))
+                ),
+            )
+        }
+        @JvmStatic
+        fun invalidAddressRequests(): Stream<Arguments> {
+            return Stream.of(
+                Arguments.of(
+                    "zip code too large",
+                    buildAddressRequestMap(mapOf("zip_code" to "a".repeat(11)))
+                ),
+                Arguments.of(
+                    "zip code null",
+                    buildAddressRequestMap(mapOf("zip_code" to null))
+                ),
+                Arguments.of(
+                    "streetNumber too large",
+                    buildAddressRequestMap(mapOf("street_number" to "a".repeat(11)))
+                ),
+                Arguments.of(
+                    "streetNumber null",
+                    buildAddressRequestMap(mapOf("street_number" to null))
+                ),
+                Arguments.of(
+                    "street too large",
+                    buildAddressRequestMap(mapOf("street" to "a".repeat(51)))
+                ),
+                Arguments.of(
+                    "street null",
+                    buildAddressRequestMap(mapOf("street" to null))
+                ),
+                Arguments.of(
+                    "apartmentNumber too large",
+                    buildAddressRequestMap(mapOf("apartment_number" to "a".repeat(6)))
+                ),
+                Arguments.of(
+                    "city_id is null",
+                    buildAddressRequestMap(mapOf("city_id" to null))
+                ),
+            )
+        }
+    }
 }

--- a/src/test/kotlin/io/billie/functional/CanStoreAndReadOrganisationTest.kt
+++ b/src/test/kotlin/io/billie/functional/CanStoreAndReadOrganisationTest.kt
@@ -18,8 +18,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.DEFINED_PORT
-import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.web.servlet.MockMvc
@@ -30,11 +29,8 @@ import java.util.*
 
 
 @AutoConfigureMockMvc
-@SpringBootTest(webEnvironment = DEFINED_PORT)
+@SpringBootTest(webEnvironment = RANDOM_PORT)
 class CanStoreAndReadOrganisationTest {
-
-    @LocalServerPort
-    private val port = 8080
 
     @Autowired
     private lateinit var mockMvc: MockMvc

--- a/src/test/kotlin/io/billie/functional/data/Fixtures.kt
+++ b/src/test/kotlin/io/billie/functional/data/Fixtures.kt
@@ -1,7 +1,8 @@
 package io.billie.functional.data
 
 import java.text.SimpleDateFormat
-import java.util.UUID
+import java.util.*
+import kotlin.collections.HashMap
 
 object Fixtures {
 
@@ -78,6 +79,29 @@ object Fixtures {
                 }"""
     }
 
+    fun orgRequestWithAddressJson(cityId: String): String {
+        return """{
+                  "name": "BBC",
+                  "date_founded": "18/10/1922",
+                  "country_code": "GB",
+                  "vat_number": "333289454",
+                  "registration_number": "3686147",
+                  "legal_entity_type": "NONPROFIT_ORGANIZATION",
+                  "contact_details": {
+                    "phone_number": "+443700100222",
+                    "fax": "",
+                    "email": "yourquestions@bbc.co.uk"
+                  },
+                  "address": {
+                    "city_id": "$cityId",
+                    "zip_code": "1046AC",
+                    "street": "Jarmuiden",
+                    "street_number": "31",
+                    "apartment_number": "4A"
+                  }
+                }"""
+    }
+
     fun orgRequestJsonCountryCodeBlank(): String {
         return """{
                   "name": "BBC",
@@ -146,5 +170,24 @@ object Fixtures {
         return data
     }
 
+    fun bbcAddressFixture(id: UUID): Map<String, Any> {
+        val data = HashMap<String, Any>()
+        data["id"] = id
+        data["zip_code"] = "1046AC"
+        data["street"] = "Jarmuiden"
+        data["street_number"] = "31"
+        data["apartment_number"] = "4A"
+        return data
+    }
+
+    fun addressRequestJson(cityId: String): String {
+        return """{
+                  "city_id": "$cityId",
+                  "zip_code": "1046AC",
+                  "street": "Jarmuiden",
+                  "street_number": "31",
+                  "apartment_number": "4A"
+                }"""
+    }
 
 }

--- a/src/test/kotlin/io/billie/functional/data/Fixtures.kt
+++ b/src/test/kotlin/io/billie/functional/data/Fixtures.kt
@@ -1,129 +1,128 @@
 package io.billie.functional.data
 
 import java.text.SimpleDateFormat
-import java.util.*
-import kotlin.collections.HashMap
+import java.util.UUID
 
 object Fixtures {
 
     fun orgRequestJsonNameBlank(): String {
-        return "{\n" +
-                "  \"name\": \"\",\n" +
-                "  \"date_founded\": \"18/10/1922\",\n" +
-                "  \"country_code\": \"GB\",\n" +
-                "  \"vat_number\": \"333289454\",\n" +
-                "  \"registration_number\": \"3686147\",\n" +
-                "  \"legal_entity_type\": \"NONPROFIT_ORGANIZATION\",\n" +
-                "  \"contact_details\": {\n" +
-                "    \"phone_number\": \"+443700100222\",\n" +
-                "    \"fax\": \"\",\n" +
-                "    \"email\": \"yourquestions@bbc.co.uk\"\n" +
-                "  }\n" +
-                "}"
+        return """{
+                  "name": "",
+                  "date_founded": "18/10/1922",
+                  "country_code": "GB",
+                  "vat_number": "333289454",
+                  "registration_number": "3686147",
+                  "legal_entity_type": "NONPROFIT_ORGANIZATION",
+                  "contact_details": {
+                    "phone_number": "+443700100222",
+                    "fax": "",
+                    "email": "yourquestions@bbc.co.uk"
+                  }
+                }"""
     }
 
     fun orgRequestJsonNoName(): String {
-        return "{\n" +
-                "  \"date_founded\": \"18/10/1922\",\n" +
-                "  \"country_code\": \"GB\",\n" +
-                "  \"vat_number\": \"333289454\",\n" +
-                "  \"registration_number\": \"3686147\",\n" +
-                "  \"legal_entity_type\": \"NONPROFIT_ORGANIZATION\",\n" +
-                "  \"contact_details\": {\n" +
-                "    \"phone_number\": \"+443700100222\",\n" +
-                "    \"fax\": \"\",\n" +
-                "    \"email\": \"yourquestions@bbc.co.uk\"\n" +
-                "  }\n" +
-                "}"
+        return """{
+                  "date_founded": "18/10/1922",
+                  "country_code": "GB",
+                  "vat_number": "333289454",
+                  "registration_number": "3686147",
+                  "legal_entity_type": "NONPROFIT_ORGANIZATION",
+                  "contact_details": {
+                    "phone_number": "+443700100222",
+                    "fax": "",
+                    "email": "yourquestions@bbc.co.uk"
+                  }
+                }"""
     }
 
     fun orgRequestJsonNoLegalEntityType(): String {
-        return "{\n" +
-                "  \"name\": \"BBC\",\n" +
-                "  \"date_founded\": \"18/10/1922\",\n" +
-                "  \"country_code\": \"GB\",\n" +
-                "  \"vat_number\": \"333289454\",\n" +
-                "  \"registration_number\": \"3686147\",\n" +
-                "  \"contact_details\": {\n" +
-                "    \"phone_number\": \"+443700100222\",\n" +
-                "    \"fax\": \"\",\n" +
-                "    \"email\": \"yourquestions@bbc.co.uk\"\n" +
-                "  }\n" +
-                "}"
+        return """{
+                  "name": "BBC",
+                  "date_founded": "18/10/1922",
+                  "country_code": "GB",
+                  "vat_number": "333289454",
+                  "registration_number": "3686147",
+                  "contact_details": {
+                    "phone_number": "+443700100222",
+                    "fax": "",
+                    "email": "yourquestions@bbc.co.uk"
+                  }
+                }"""
     }
 
     fun orgRequestJsonNoContactDetails(): String {
-        return "{\n" +
-                "  \"name\": \"BBC\",\n" +
-                "  \"date_founded\": \"18/10/1922\",\n" +
-                "  \"country_code\": \"GB\",\n" +
-                "  \"vat_number\": \"333289454\",\n" +
-                "  \"registration_number\": \"3686147\",\n" +
-                "  \"legal_entity_type\": \"NONPROFIT_ORGANIZATION\"\n" +
-                "}"
+        return """{
+                  "name": "BBC",
+                  "date_founded": "18/10/1922",
+                  "country_code": "GB",
+                  "vat_number": "333289454",
+                  "registration_number": "3686147",
+                  "legal_entity_type": "NONPROFIT_ORGANIZATION"
+                }"""
     }
 
     fun orgRequestJson(): String {
-        return "{\n" +
-                "  \"name\": \"BBC\",\n" +
-                "  \"date_founded\": \"18/10/1922\",\n" +
-                "  \"country_code\": \"GB\",\n" +
-                "  \"vat_number\": \"333289454\",\n" +
-                "  \"registration_number\": \"3686147\",\n" +
-                "  \"legal_entity_type\": \"NONPROFIT_ORGANIZATION\",\n" +
-                "  \"contact_details\": {\n" +
-                "    \"phone_number\": \"+443700100222\",\n" +
-                "    \"fax\": \"\",\n" +
-                "    \"email\": \"yourquestions@bbc.co.uk\"\n" +
-                "  }\n" +
-                "}"
+        return """{
+                  "name": "BBC",
+                  "date_founded": "18/10/1922",
+                  "country_code": "GB",
+                  "vat_number": "333289454",
+                  "registration_number": "3686147",
+                  "legal_entity_type": "NONPROFIT_ORGANIZATION",
+                  "contact_details": {
+                    "phone_number": "+443700100222",
+                    "fax": "",
+                    "email": "yourquestions@bbc.co.uk"
+                  }
+                }"""
     }
 
     fun orgRequestJsonCountryCodeBlank(): String {
-        return "{\n" +
-                "  \"name\": \"BBC\",\n" +
-                "  \"date_founded\": \"18/10/1922\",\n" +
-                "  \"country_code\": \"\",\n" +
-                "  \"vat_number\": \"333289454\",\n" +
-                "  \"registration_number\": \"3686147\",\n" +
-                "  \"legal_entity_type\": \"NONPROFIT_ORGANIZATION\",\n" +
-                "  \"contact_details\": {\n" +
-                "    \"phone_number\": \"+443700100222\",\n" +
-                "    \"fax\": \"\",\n" +
-                "    \"email\": \"yourquestions@bbc.co.uk\"\n" +
-                "  }\n" +
-                "}"
+        return """{
+                  "name": "BBC",
+                  "date_founded": "18/10/1922",
+                  "country_code": "",
+                  "vat_number": "333289454",
+                  "registration_number": "3686147",
+                  "legal_entity_type": "NONPROFIT_ORGANIZATION",
+                  "contact_details": {
+                    "phone_number": "+443700100222",
+                    "fax": "",
+                    "email": "yourquestions@bbc.co.uk"
+                  }
+                }"""
     }
 
     fun orgRequestJsonNoCountryCode(): String {
-        return "{\n" +
-                "  \"name\": \"BBC\",\n" +
-                "  \"date_founded\": \"18/10/1922\",\n" +
-                "  \"vat_number\": \"333289454\",\n" +
-                "  \"registration_number\": \"3686147\",\n" +
-                "  \"legal_entity_type\": \"NONPROFIT_ORGANIZATION\",\n" +
-                "  \"contact_details\": {\n" +
-                "    \"phone_number\": \"+443700100222\",\n" +
-                "    \"fax\": \"\",\n" +
-                "    \"email\": \"yourquestions@bbc.co.uk\"\n" +
-                "  }\n" +
-                "}"
+        return """{
+                  "name": "BBC",
+                  "date_founded": "18/10/1922",
+                  "vat_number": "333289454",
+                  "registration_number": "3686147",
+                  "legal_entity_type": "NONPROFIT_ORGANIZATION",
+                  "contact_details": {
+                    "phone_number": "+443700100222",
+                    "fax": "",
+                    "email": "yourquestions@bbc.co.uk"
+                  }
+                }"""
     }
 
     fun orgRequestJsonCountryCodeIncorrect(): String {
-        return "{\n" +
-                "  \"name\": \"BBC\",\n" +
-                "  \"date_founded\": \"18/10/1922\",\n" +
-                "  \"country_code\": \"XX\",\n" +
-                "  \"vat_number\": \"333289454\",\n" +
-                "  \"registration_number\": \"3686147\",\n" +
-                "  \"legal_entity_type\": \"NONPROFIT_ORGANIZATION\",\n" +
-                "  \"contact_details\": {\n" +
-                "    \"phone_number\": \"+443700100222\",\n" +
-                "    \"fax\": \"\",\n" +
-                "    \"email\": \"yourquestions@bbc.co.uk\"\n" +
-                "  }\n" +
-                "}"
+        return """{
+                  "name": "BBC",
+                  "date_founded": "18/10/1922",
+                  "country_code": "XX",
+                  "vat_number": "333289454",
+                  "registration_number": "3686147",
+                  "legal_entity_type": "NONPROFIT_ORGANIZATION",
+                  "contact_details": {
+                    "phone_number": "+443700100222",
+                    "fax": "",
+                    "email": "yourquestions@bbc.co.uk"
+                  }
+                }"""
     }
 
     fun bbcFixture(id: UUID): Map<String, Any> {
@@ -146,7 +145,6 @@ object Fixtures {
         data["email"] = "yourquestions@bbc.co.uk"
         return data
     }
-
 
 
 }

--- a/src/test/kotlin/io/billie/organisations/service/OrganisationServiceTest.kt
+++ b/src/test/kotlin/io/billie/organisations/service/OrganisationServiceTest.kt
@@ -1,0 +1,56 @@
+package io.billie.organisations.service
+
+import io.billie.countries.data.CityRepository
+import io.billie.organisations.data.OrganisationRepository
+import io.billie.organisations.data.UnableToFindCity
+import io.billie.organisations.data.UnableToFindOrganisation
+import io.billie.organisations.viewmodel.AddressRequest
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.junit.jupiter.MockitoExtension
+import java.util.*
+
+@ExtendWith(MockitoExtension::class)
+class OrganisationServiceTest {
+
+    @Mock
+    private lateinit var organisationRepository: OrganisationRepository
+
+    @Mock
+    private lateinit var cityRepository: CityRepository
+
+    @InjectMocks
+    private lateinit var organisationService: OrganisationService
+
+    @Test
+    fun `validateCityExists throws UnableToFindCity exception when city does not exist`() {
+        val organisationId = UUID.randomUUID().toString()
+        val cityId = UUID.randomUUID().toString()
+        Mockito.`when`(organisationRepository.existsById(UUID.fromString(organisationId))).thenReturn(true)
+        Mockito.`when`(cityRepository.existsById(UUID.fromString(cityId))).thenReturn(false)
+
+        assertThrows(UnableToFindCity::class.java) {
+            organisationService.addAddressToOrganisation(
+                organisationId,
+                AddressRequest(cityId = cityId, "", "", "")
+            )
+        }
+    }
+
+    @Test
+    fun `validateOrganisationExists throws UnableToFindOrganisation exception when organisation does not exist`() {
+        val organisationId = UUID.randomUUID().toString()
+        val cityId = UUID.randomUUID().toString()
+        Mockito.`when`(organisationRepository.existsById(UUID.fromString(organisationId))).thenReturn(false)
+
+        assertThrows(UnableToFindOrganisation::class.java) {
+            organisationService.addAddressToOrganisation(
+                organisationId,
+                AddressRequest(cityId = cityId, "", "", ""))
+        }
+    }
+}


### PR DESCRIPTION
Now it's possible to add an address to an existing organisation or to create an organisation directly with its address.

Some details about implementation:
- Use string blocks for multiline strings.
- Run integration tests in random ports.
- jdbcTemplate is private now and injected in constructor
- queries are in string blocks to improve readability
- now it's possible to add an address to an existing organisation and to new ones. The address is optional for retro-compatibility.
- basic http exception handler
- now it's possible to run the service using docker compose
- removed flyway plugin and included flyway core to run migrations automatically
- basic validations for AddressRequest
