### PR TITLE
Add addresses to organizations

### DIFF
--- a/src/main/kotlin/io/billie/countries/data/CityRepository.kt
+++ b/src/main/kotlin/io/billie/countries/data/CityRepository.kt
@@ -25,6 +25,16 @@ class CityRepository {
         )
     }
 
+    @Transactional(readOnly = true)
+    fun findByNameAndCountryCode(name: String, countryCode: String): CityResponse {
+        return jdbcTemplate.query(
+            "select id, name, country_code from organisations_schema.cities where name = ? and country_code = ?",
+            cityResponseMapper(),
+            name,
+            countryCode
+        ).firstOrNull() ?: throw UnableToFindCity(name, countryCode)
+    }
+
     private fun cityResponseMapper() = RowMapper<CityResponse> { it: ResultSet, _: Int ->
         CityResponse(
             it.getObject("id", UUID::class.java),

--- a/src/main/kotlin/io/billie/countries/data/UnableToFindCity.kt
+++ b/src/main/kotlin/io/billie/countries/data/UnableToFindCity.kt
@@ -1,0 +1,3 @@
+package io.billie.countries.data
+
+class UnableToFindCity(val name: String, val countryCode: String) : RuntimeException()

--- a/src/main/kotlin/io/billie/countries/service/CountryService.kt
+++ b/src/main/kotlin/io/billie/countries/service/CountryService.kt
@@ -14,4 +14,6 @@ class CountryService(val dbCountry: CountryRepository, val dbCity: CityRepositor
     }
     fun findCities(countryCode: String): List<CityResponse> = dbCity.findByCountryCode(countryCode)
 
+    fun findCity(name: String, countryCode: String): CityResponse = dbCity.findByNameAndCountryCode(name, countryCode)
+
 }

--- a/src/main/kotlin/io/billie/organisations/service/OrganisationService.kt
+++ b/src/main/kotlin/io/billie/organisations/service/OrganisationService.kt
@@ -1,5 +1,6 @@
 package io.billie.organisations.service
 
+import io.billie.countries.service.CountryService
 import io.billie.organisations.data.OrganisationRepository
 import io.billie.organisations.viewmodel.OrganisationRequest
 import io.billie.organisations.viewmodel.OrganisationResponse
@@ -7,12 +8,13 @@ import org.springframework.stereotype.Service
 import java.util.*
 
 @Service
-class OrganisationService(val db: OrganisationRepository) {
+class OrganisationService(val db: OrganisationRepository, val countryService: CountryService) {
 
     fun findOrganisations(): List<OrganisationResponse> = db.findOrganisations()
 
     fun createOrganisation(organisation: OrganisationRequest): UUID {
-        return db.create(organisation)
+        val city = countryService.findCity(organisation.address.city, organisation.address.countryCode)
+        return db.create(organisation, city.id)
     }
 
 }

--- a/src/main/kotlin/io/billie/organisations/viewmodel/Address.kt
+++ b/src/main/kotlin/io/billie/organisations/viewmodel/Address.kt
@@ -1,0 +1,14 @@
+package io.billie.organisations.viewmodel
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import java.util.UUID
+
+class Address(
+    val id: UUID,
+    @JsonProperty("country_code") val countryCode: String,
+    val city: String,
+    val street: String,
+    @JsonProperty("house_number") val houseNumber: String,
+    @JsonProperty("postal_code") val postalCode: String,
+    @JsonProperty("additional_info") val additionalInfo: String?
+)

--- a/src/main/kotlin/io/billie/organisations/viewmodel/AddressRequest.kt
+++ b/src/main/kotlin/io/billie/organisations/viewmodel/AddressRequest.kt
@@ -1,0 +1,12 @@
+package io.billie.organisations.viewmodel
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class AddressRequest(
+    @JsonProperty("country_code") val countryCode: String,
+    val city: String,
+    val street: String,
+    @JsonProperty("house_number") val houseNumber: String,
+    @JsonProperty("postal_code") val postalCode: String,
+    @JsonProperty("additional_info") val additionalInfo: String?
+)

--- a/src/main/kotlin/io/billie/organisations/viewmodel/OrganisationRequest.kt
+++ b/src/main/kotlin/io/billie/organisations/viewmodel/OrganisationRequest.kt
@@ -16,4 +16,5 @@ data class OrganisationRequest(
     @JsonProperty("registration_number") val registrationNumber: String?,
     @JsonProperty("legal_entity_type") val legalEntityType: LegalEntityType,
     @JsonProperty("contact_details") val contactDetails: ContactDetailsRequest,
+    @JsonProperty("address") val address: AddressRequest
 )

--- a/src/main/kotlin/io/billie/organisations/viewmodel/OrganisationResponse.kt
+++ b/src/main/kotlin/io/billie/organisations/viewmodel/OrganisationResponse.kt
@@ -17,4 +17,5 @@ data class OrganisationResponse(
     @JsonProperty("registration_number") val registrationNumber: String?,
     @JsonProperty("legal_entity_type") val legalEntityType: LegalEntityType,
     @JsonProperty("contact_details") val contactDetails: ContactDetails,
+    val address: Address
 )

--- a/src/main/resources/db/migration/V9__Add_address.sql
+++ b/src/main/resources/db/migration/V9__Add_address.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS organisations_schema.addresses
+(
+    id             UUID DEFAULT uuid_generate_v4() PRIMARY KEY,
+    city_id        UUID REFERENCES organisations_schema.cities(id),
+    street         VARCHAR(255) NOT NULL,
+    house_number   VARCHAR(255) NOT NULL,
+    postal_code    VARCHAR(255) NOT NULL,
+    additional_info VARCHAR(255) NOT NULL
+);
+
+ALTER TABLE organisations_schema.organisations
+ADD COLUMN address_id UUID REFERENCES organisations_schema.addresses(id);

--- a/src/test/kotlin/io/billie/functional/CanStoreAndReadOrganisationTest.kt
+++ b/src/test/kotlin/io/billie/functional/CanStoreAndReadOrganisationTest.kt
@@ -1,16 +1,30 @@
 package io.billie.functional
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import io.billie.functional.data.Fixtures.bbcAddressFixture
 import io.billie.functional.data.Fixtures.bbcContactFixture
 import io.billie.functional.data.Fixtures.bbcFixture
+import io.billie.functional.data.Fixtures.orgRequestAddressCityBlank
+import io.billie.functional.data.Fixtures.orgRequestAddressCityIsIncorrect
+import io.billie.functional.data.Fixtures.orgRequestAddressCountryCodeBlank
+import io.billie.functional.data.Fixtures.orgRequestAddressCountryCodeIsIncorrect
+import io.billie.functional.data.Fixtures.orgRequestAddressHouseNumberBlank
+import io.billie.functional.data.Fixtures.orgRequestAddressNoCity
+import io.billie.functional.data.Fixtures.orgRequestAddressNoCountryCode
+import io.billie.functional.data.Fixtures.orgRequestAddressNoHouseNumber
+import io.billie.functional.data.Fixtures.orgRequestAddressNoPostalCode
+import io.billie.functional.data.Fixtures.orgRequestAddressNoStreet
+import io.billie.functional.data.Fixtures.orgRequestAddressPostalCodeBlank
+import io.billie.functional.data.Fixtures.orgRequestAddressStreetBlank
 import io.billie.functional.data.Fixtures.orgRequestJson
 import io.billie.functional.data.Fixtures.orgRequestJsonCountryCodeBlank
 import io.billie.functional.data.Fixtures.orgRequestJsonCountryCodeIncorrect
-import io.billie.functional.data.Fixtures.orgRequestJsonNoName
 import io.billie.functional.data.Fixtures.orgRequestJsonNameBlank
 import io.billie.functional.data.Fixtures.orgRequestJsonNoContactDetails
 import io.billie.functional.data.Fixtures.orgRequestJsonNoCountryCode
 import io.billie.functional.data.Fixtures.orgRequestJsonNoLegalEntityType
+import io.billie.functional.data.Fixtures.orgRequestJsonNoName
+import io.billie.functional.data.Fixtures.orgRequestNoAddress
 import io.billie.organisations.viewmodel.Entity
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.core.IsEqual.equalTo
@@ -26,8 +40,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
-import java.util.*
-
+import java.util.UUID
 
 @AutoConfigureMockMvc
 @SpringBootTest(webEnvironment = DEFINED_PORT)
@@ -109,6 +122,109 @@ class CanStoreAndReadOrganisationTest {
         )
             .andExpect(status().isBadRequest)
     }
+    @Test
+    fun cannotStoreOrgWhenNoAddressGiven() {
+        mockMvc.perform(
+            post("/organisations").contentType(APPLICATION_JSON).content(orgRequestNoAddress())
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun cannotStoreOrgWhenAddressCountryCodeIsMissing() {
+        mockMvc.perform(
+            post("/organisations").contentType(APPLICATION_JSON).content(orgRequestAddressNoCountryCode())
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun cannotStoreOrgWhenAddressCountryCodeIsBlank() {
+        mockMvc.perform(
+            post("/organisations").contentType(APPLICATION_JSON).content(orgRequestAddressCountryCodeBlank())
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun cannotStoreOrgWhenAddressCountryCodeIsIncorrect() {
+        mockMvc.perform(
+            post("/organisations").contentType(APPLICATION_JSON).content(orgRequestAddressCountryCodeIsIncorrect())
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun cannotStoreOrgWhenAddressCityIsIncorrect() {
+        mockMvc.perform(
+            post("/organisations").contentType(APPLICATION_JSON).content(orgRequestAddressCityIsIncorrect())
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun cannotStoreOrgWhenAddressCityIsMissing() {
+        mockMvc.perform(
+            post("/organisations").contentType(APPLICATION_JSON).content(orgRequestAddressNoCity())
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun cannotStoreOrgWhenAddressCityIsBlank() {
+        mockMvc.perform(
+            post("/organisations").contentType(APPLICATION_JSON).content(orgRequestAddressCityBlank())
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun cannotStoreOrgWhenAddressStreetIsMissing() {
+        mockMvc.perform(
+            post("/organisations").contentType(APPLICATION_JSON).content(orgRequestAddressNoStreet())
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun cannotStoreOrgWhenAddressStreetIsBlank() {
+        mockMvc.perform(
+            post("/organisations").contentType(APPLICATION_JSON).content(orgRequestAddressStreetBlank())
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun cannotStoreOrgWhenAddressHouseNumberIsMissing() {
+        mockMvc.perform(
+            post("/organisations").contentType(APPLICATION_JSON).content(orgRequestAddressNoHouseNumber())
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun cannotStoreOrgWhenAddressHouseNumberIsBlank() {
+        mockMvc.perform(
+            post("/organisations").contentType(APPLICATION_JSON).content(orgRequestAddressHouseNumberBlank())
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun cannotStoreOrgWhenAddressPostalCodeIsMissing() {
+        mockMvc.perform(
+            post("/organisations").contentType(APPLICATION_JSON).content(orgRequestAddressNoPostalCode())
+        )
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun cannotStoreOrgWhenAddressPostalCodeIsBlank() {
+        mockMvc.perform(
+            post("/organisations").contentType(APPLICATION_JSON).content(orgRequestAddressPostalCodeBlank())
+        )
+            .andExpect(status().isBadRequest)
+    }
 
     @Test
     fun canStoreOrg() {
@@ -126,6 +242,10 @@ class CanStoreAndReadOrganisationTest {
         val contactDetailsId: UUID = UUID.fromString(org["contact_details_id"] as String)
         val contactDetails: Map<String, Any> = contactDetailsFromDatabase(contactDetailsId)
         assertDataMatches(contactDetails, bbcContactFixture(contactDetailsId))
+
+        val addressId: UUID = org["address_id"] as UUID
+        val address: Map<String, Any> = addressFromDatabase(addressId)
+        assertDataMatches(address, bbcAddressFixture(addressId))
     }
 
     fun assertDataMatches(reply: Map<String, Any>, assertions: Map<String, Any>) {
@@ -142,5 +262,10 @@ class CanStoreAndReadOrganisationTest {
 
     private fun contactDetailsFromDatabase(id: UUID): MutableMap<String, Any> =
         queryEntityFromDatabase("select * from organisations_schema.contact_details where id = ?", id)
+
+    private fun addressFromDatabase(id: UUID): MutableMap<String, Any> =
+        queryEntityFromDatabase("select a.*, ct.country_code as address_country_code, ct.name as address_city " +
+            "from organisations_schema.addresses a " +
+            "INNER JOIN organisations_schema.cities ct on a.city_id::uuid = ct.id::uuid  where a.id = ?", id)
 
 }

--- a/src/test/kotlin/io/billie/functional/data/Fixtures.kt
+++ b/src/test/kotlin/io/billie/functional/data/Fixtures.kt
@@ -63,6 +63,294 @@ object Fixtures {
                 "}"
     }
 
+    fun orgRequestNoAddress(): String {
+        return "{\n" +
+            "  \"name\": \"BBC\",\n" +
+            "  \"date_founded\": \"18/10/1922\",\n" +
+            "  \"country_code\": \"GB\",\n" +
+            "  \"vat_number\": \"333289454\",\n" +
+            "  \"registration_number\": \"3686147\",\n" +
+            "  \"legal_entity_type\": \"NONPROFIT_ORGANIZATION\",\n" +
+            "  \"contact_details\": {\n" +
+            "    \"phone_number\": \"+443700100222\",\n" +
+            "    \"fax\": \"\",\n" +
+            "    \"email\": \"yourquestions@bbc.co.uk\"\n" +
+            "  }\n" +
+            "}"
+    }
+
+    fun orgRequestAddressCountryCodeBlank(): String {
+        return "{\n" +
+                "  \"name\": \"BBC\",\n" +
+                "  \"date_founded\": \"18/10/1922\",\n" +
+                "  \"country_code\": \"GB\",\n" +
+                "  \"vat_number\": \"333289454\",\n" +
+                "  \"registration_number\": \"3686147\",\n" +
+                "  \"legal_entity_type\": \"NONPROFIT_ORGANIZATION\",\n" +
+                "  \"contact_details\": {\n" +
+                "    \"phone_number\": \"+443700100222\",\n" +
+                "    \"fax\": \"\",\n" +
+                "    \"email\": \"yourquestions@bbc.co.uk\"\n" +
+                "  },\n" +
+                "  \"address\": {\n" +
+                "    \"country_code\": \"\",\n" +
+                "    \"city\": \"Lake City\",\n" +
+                "    \"street\": \"NE Leon St\",\n" +
+                "    \"house_number\": \"156\",\n" +
+                "    \"postal_code\": \"FL 32055\",\n" +
+                "  }\n" +
+                "}"
+    }
+
+    fun orgRequestAddressNoCountryCode(): String {
+        return "{\n" +
+            "  \"name\": \"BBC\",\n" +
+            "  \"date_founded\": \"18/10/1922\",\n" +
+            "  \"country_code\": \"GB\",\n" +
+            "  \"vat_number\": \"333289454\",\n" +
+            "  \"registration_number\": \"3686147\",\n" +
+            "  \"legal_entity_type\": \"NONPROFIT_ORGANIZATION\",\n" +
+            "  \"contact_details\": {\n" +
+            "    \"phone_number\": \"+443700100222\",\n" +
+            "    \"fax\": \"\",\n" +
+            "    \"email\": \"yourquestions@bbc.co.uk\"\n" +
+            "  },\n" +
+            "  \"address\": {\n" +
+            "    \"city\": \"Lake City\",\n" +
+            "    \"street\": \"NE Leon St\",\n" +
+            "    \"house_number\": \"156\",\n" +
+            "    \"postal_code\": \"FL 32055\",\n" +
+            "  }\n" +
+            "}"
+    }
+
+    fun orgRequestAddressCountryCodeIsIncorrect(): String {
+        return "{\n" +
+            "  \"name\": \"BBC\",\n" +
+            "  \"date_founded\": \"18/10/1922\",\n" +
+            "  \"country_code\": \"GB\",\n" +
+            "  \"vat_number\": \"333289454\",\n" +
+            "  \"registration_number\": \"3686147\",\n" +
+            "  \"legal_entity_type\": \"NONPROFIT_ORGANIZATION\",\n" +
+            "  \"contact_details\": {\n" +
+            "    \"phone_number\": \"+443700100222\",\n" +
+            "    \"fax\": \"\",\n" +
+            "    \"email\": \"yourquestions@bbc.co.uk\"\n" +
+            "  },\n" +
+            "  \"address\": {\n" +
+            "    \"country_code\": \"US123\",\n" +
+            "    \"city\": \"Lake City\",\n" +
+            "    \"street\": \"NE Leon St\",\n" +
+            "    \"house_number\": \"156\",\n" +
+            "    \"postal_code\": \"FL 32055\",\n" +
+            "  }\n" +
+            "}"
+    }
+
+    fun orgRequestAddressCityBlank(): String {
+        return "{\n" +
+            "  \"name\": \"BBC\",\n" +
+            "  \"date_founded\": \"18/10/1922\",\n" +
+            "  \"country_code\": \"GB\",\n" +
+            "  \"vat_number\": \"333289454\",\n" +
+            "  \"registration_number\": \"3686147\",\n" +
+            "  \"legal_entity_type\": \"NONPROFIT_ORGANIZATION\",\n" +
+            "  \"contact_details\": {\n" +
+            "    \"phone_number\": \"+443700100222\",\n" +
+            "    \"fax\": \"\",\n" +
+            "    \"email\": \"yourquestions@bbc.co.uk\"\n" +
+            "  },\n" +
+            "  \"address\": {\n" +
+            "    \"country_code\": \"US\",\n" +
+            "    \"city\": \"\",\n" +
+            "    \"street\": \"NE Leon St\",\n" +
+            "    \"house_number\": \"156\",\n" +
+            "    \"postal_code\": \"FL 32055\",\n" +
+            "  }\n" +
+            "}"
+    }
+
+    fun orgRequestAddressNoCity(): String {
+        return "{\n" +
+            "  \"name\": \"BBC\",\n" +
+            "  \"date_founded\": \"18/10/1922\",\n" +
+            "  \"country_code\": \"GB\",\n" +
+            "  \"vat_number\": \"333289454\",\n" +
+            "  \"registration_number\": \"3686147\",\n" +
+            "  \"legal_entity_type\": \"NONPROFIT_ORGANIZATION\",\n" +
+            "  \"contact_details\": {\n" +
+            "    \"phone_number\": \"+443700100222\",\n" +
+            "    \"fax\": \"\",\n" +
+            "    \"email\": \"yourquestions@bbc.co.uk\"\n" +
+            "  },\n" +
+            "  \"address\": {\n" +
+            "    \"country_code\": \"US\",\n" +
+            "    \"street\": \"NE Leon St\",\n" +
+            "    \"house_number\": \"156\",\n" +
+            "    \"postal_code\": \"FL 32055\",\n" +
+            "  }\n" +
+            "}"
+    }
+
+    fun orgRequestAddressCityIsIncorrect(): String {
+        return "{\n" +
+            "  \"name\": \"BBC\",\n" +
+            "  \"date_founded\": \"18/10/1922\",\n" +
+            "  \"country_code\": \"GB\",\n" +
+            "  \"vat_number\": \"333289454\",\n" +
+            "  \"registration_number\": \"3686147\",\n" +
+            "  \"legal_entity_type\": \"NONPROFIT_ORGANIZATION\",\n" +
+            "  \"contact_details\": {\n" +
+            "    \"phone_number\": \"+443700100222\",\n" +
+            "    \"fax\": \"\",\n" +
+            "    \"email\": \"yourquestions@bbc.co.uk\"\n" +
+            "  },\n" +
+            "  \"address\": {\n" +
+            "    \"country_code\": \"US\",\n" +
+            "    \"city\": \"Lake City123\",\n" +
+            "    \"street\": \"NE Leon St\",\n" +
+            "    \"house_number\": \"156\",\n" +
+            "    \"postal_code\": \"FL 32055\",\n" +
+            "  }\n" +
+            "}"
+    }
+
+    fun orgRequestAddressStreetBlank(): String {
+        return "{\n" +
+            "  \"name\": \"BBC\",\n" +
+            "  \"date_founded\": \"18/10/1922\",\n" +
+            "  \"country_code\": \"GB\",\n" +
+            "  \"vat_number\": \"333289454\",\n" +
+            "  \"registration_number\": \"3686147\",\n" +
+            "  \"legal_entity_type\": \"NONPROFIT_ORGANIZATION\",\n" +
+            "  \"contact_details\": {\n" +
+            "    \"phone_number\": \"+443700100222\",\n" +
+            "    \"fax\": \"\",\n" +
+            "    \"email\": \"yourquestions@bbc.co.uk\"\n" +
+            "  },\n" +
+            "  \"address\": {\n" +
+            "    \"country_code\": \"US\",\n" +
+            "    \"city\": \"Lake City123\",\n" +
+            "    \"street\": \"\",\n" +
+            "    \"house_number\": \"156\",\n" +
+            "    \"postal_code\": \"FL 32055\",\n" +
+            "  }\n" +
+            "}"
+    }
+
+    fun orgRequestAddressNoStreet(): String {
+        return "{\n" +
+            "  \"name\": \"BBC\",\n" +
+            "  \"date_founded\": \"18/10/1922\",\n" +
+            "  \"country_code\": \"GB\",\n" +
+            "  \"vat_number\": \"333289454\",\n" +
+            "  \"registration_number\": \"3686147\",\n" +
+            "  \"legal_entity_type\": \"NONPROFIT_ORGANIZATION\",\n" +
+            "  \"contact_details\": {\n" +
+            "    \"phone_number\": \"+443700100222\",\n" +
+            "    \"fax\": \"\",\n" +
+            "    \"email\": \"yourquestions@bbc.co.uk\"\n" +
+            "  },\n" +
+            "  \"address\": {\n" +
+            "    \"country_code\": \"US\",\n" +
+            "    \"city\": \"Lake City\",\n" +
+            "    \"house_number\": \"156\",\n" +
+            "    \"postal_code\": \"FL 32055\",\n" +
+            "  }\n" +
+            "}"
+    }
+
+    fun orgRequestAddressHouseNumberBlank(): String {
+        return "{\n" +
+            "  \"name\": \"BBC\",\n" +
+            "  \"date_founded\": \"18/10/1922\",\n" +
+            "  \"country_code\": \"GB\",\n" +
+            "  \"vat_number\": \"333289454\",\n" +
+            "  \"registration_number\": \"3686147\",\n" +
+            "  \"legal_entity_type\": \"NONPROFIT_ORGANIZATION\",\n" +
+            "  \"contact_details\": {\n" +
+            "    \"phone_number\": \"+443700100222\",\n" +
+            "    \"fax\": \"\",\n" +
+            "    \"email\": \"yourquestions@bbc.co.uk\"\n" +
+            "  },\n" +
+            "  \"address\": {\n" +
+            "    \"country_code\": \"US\",\n" +
+            "    \"city\": \"Lake City123\",\n" +
+            "    \"street\": \"NE Leon St\",\n" +
+            "    \"house_number\": \"\",\n" +
+            "    \"postal_code\": \"FL 32055\",\n" +
+            "  }\n" +
+            "}"
+    }
+
+    fun orgRequestAddressNoHouseNumber(): String {
+        return "{\n" +
+            "  \"name\": \"BBC\",\n" +
+            "  \"date_founded\": \"18/10/1922\",\n" +
+            "  \"country_code\": \"GB\",\n" +
+            "  \"vat_number\": \"333289454\",\n" +
+            "  \"registration_number\": \"3686147\",\n" +
+            "  \"legal_entity_type\": \"NONPROFIT_ORGANIZATION\",\n" +
+            "  \"contact_details\": {\n" +
+            "    \"phone_number\": \"+443700100222\",\n" +
+            "    \"fax\": \"\",\n" +
+            "    \"email\": \"yourquestions@bbc.co.uk\"\n" +
+            "  },\n" +
+            "  \"address\": {\n" +
+            "    \"country_code\": \"US\",\n" +
+            "    \"city\": \"Lake City123\",\n" +
+            "    \"street\": \"NE Leon St\",\n" +
+            "    \"postal_code\": \"FL 32055\",\n" +
+            "  }\n" +
+            "}"
+    }
+
+    fun orgRequestAddressPostalCodeBlank(): String {
+        return "{\n" +
+            "  \"name\": \"BBC\",\n" +
+            "  \"date_founded\": \"18/10/1922\",\n" +
+            "  \"country_code\": \"GB\",\n" +
+            "  \"vat_number\": \"333289454\",\n" +
+            "  \"registration_number\": \"3686147\",\n" +
+            "  \"legal_entity_type\": \"NONPROFIT_ORGANIZATION\",\n" +
+            "  \"contact_details\": {\n" +
+            "    \"phone_number\": \"+443700100222\",\n" +
+            "    \"fax\": \"\",\n" +
+            "    \"email\": \"yourquestions@bbc.co.uk\"\n" +
+            "  },\n" +
+            "  \"address\": {\n" +
+            "    \"country_code\": \"US\",\n" +
+            "    \"city\": \"Lake City123\",\n" +
+            "    \"street\": \"NE Leon St\",\n" +
+            "    \"house_number\": \"156\",\n" +
+            "    \"postal_code\": \"\",\n" +
+            "  }\n" +
+            "}"
+    }
+
+    fun orgRequestAddressNoPostalCode(): String {
+        return "{\n" +
+            "  \"name\": \"BBC\",\n" +
+            "  \"date_founded\": \"18/10/1922\",\n" +
+            "  \"country_code\": \"GB\",\n" +
+            "  \"vat_number\": \"333289454\",\n" +
+            "  \"registration_number\": \"3686147\",\n" +
+            "  \"legal_entity_type\": \"NONPROFIT_ORGANIZATION\",\n" +
+            "  \"contact_details\": {\n" +
+            "    \"phone_number\": \"+443700100222\",\n" +
+            "    \"fax\": \"\",\n" +
+            "    \"email\": \"yourquestions@bbc.co.uk\"\n" +
+            "  },\n" +
+            "  \"address\": {\n" +
+            "    \"country_code\": \"US\",\n" +
+            "    \"city\": \"Lake City123\",\n" +
+            "    \"street\": \"NE Leon St\",\n" +
+            "    \"house_number\": \"156\",\n" +
+            "  }\n" +
+            "}"
+    }
+
+
     fun orgRequestJson(): String {
         return "{\n" +
                 "  \"name\": \"BBC\",\n" +
@@ -75,6 +363,14 @@ object Fixtures {
                 "    \"phone_number\": \"+443700100222\",\n" +
                 "    \"fax\": \"\",\n" +
                 "    \"email\": \"yourquestions@bbc.co.uk\"\n" +
+                "  },\n" +
+                "  \"address\": {\n" +
+                "    \"country_code\": \"US\",\n" +
+                "    \"city\": \"Lake City\",\n" +
+                "    \"street\": \"NE Leon St\",\n" +
+                "    \"house_number\": \"156\",\n" +
+                "    \"postal_code\": \"FL 32055\",\n" +
+                "    \"additional_info\": \"some info\"\n" +
                 "  }\n" +
                 "}"
     }
@@ -147,6 +443,15 @@ object Fixtures {
         return data
     }
 
-
-
+    fun bbcAddressFixture(id: UUID): Map<String, Any> {
+        val data = HashMap<String, Any>()
+        data["id"] = id
+        data["address_country_code"] = "US"
+        data["address_city"] = "Lake City"
+        data["street"] = "NE Leon St"
+        data["house_number"] = "156"
+        data["postal_code"] = "FL 32055"
+        data["additional_info"] = "some info"
+        return data
+    }
 }


### PR DESCRIPTION
Implements a feature: Add address to an organisation.

Assumptions and ideas:

- I decided to keep **country_code** in organization while address has a **city_id** reference which is also derived from country_code + city_name. I assumed that org country and address country could be different.
- Some cities in the seeded table are ambiguous(for example Lake City - US is presented 3 times) so I am just taking the first one that matches country_code+name criteria, but for production ready app we should get rid of such ambiguity.